### PR TITLE
Fix droppable indexing for ranking drag/drop

### DIFF
--- a/src/components/ranking/RankingsSection.tsx
+++ b/src/components/ranking/RankingsSection.tsx
@@ -50,7 +50,7 @@ export const RankingsSection: React.FC<RankingsSectionProps> = React.memo(({
     // FIXED: Use consistent ID strategy that aligns with draggable cards
     // - Filled slots: ranking-${pokemon.id} (matches draggable cards and SortableContext)
     // - Empty slots: ranking-position-${index} (for insertion points)
-    const droppableId = pokemon ? `ranking-${pokemon.id}` : `ranking-position-${index}`;
+    const droppableId = `ranking-${pokemon ? pokemon.id : 'position-' + index}`;
     
     const { setNodeRef, isOver } = useDroppable({ 
       id: droppableId,

--- a/src/hooks/ranking/handlers/availableToDragHandler.ts
+++ b/src/hooks/ranking/handlers/availableToDragHandler.ts
@@ -18,7 +18,7 @@ export const handleAvailableToRankingsDrop = (
   const isValidDropTarget = (
     overId === 'rankings-drop-zone' ||
     overId === 'rankings-grid-drop-zone' ||
-    overId.startsWith('ranking-') ||
+    /^ranking-(?:position-)?\d+$/.test(overId) ||
     over.data?.current?.type === 'ranking-position' ||
     over.data?.current?.type === 'ranked-pokemon' ||
     over.data?.current?.type === 'rankings-container' ||
@@ -66,10 +66,14 @@ export const handleAvailableToRankingsDrop = (
         console.log(`🔥 [ADD_NEW_POKEMON] Inserting before Pokemon ${targetPokemonId} at position ${targetIndex}`);
       }
     } else if (positionIndex !== null) {
-      // Dropped on an empty slot - use the position index
-      if (positionIndex >= 0 && positionIndex <= localRankings.length) {
-        insertionPosition = positionIndex;
-        console.log(`🔥 [ADD_NEW_POKEMON] Inserting at empty slot position ${positionIndex}`);
+      // Dropped on an empty slot - prefer the droppable data index
+      const dataIndex = over.data?.current?.index;
+      const finalIndex = dataIndex !== undefined ? dataIndex : positionIndex;
+      if (finalIndex >= 0 && finalIndex <= localRankings.length) {
+        insertionPosition = finalIndex;
+        console.log(
+          `🔥 [ADD_NEW_POKEMON] Inserting at empty slot position ${finalIndex} (from ${dataIndex !== undefined ? 'data' : 'id'})`
+        );
       }
     }
     

--- a/src/hooks/ranking/handlers/reorderHandler.ts
+++ b/src/hooks/ranking/handlers/reorderHandler.ts
@@ -26,10 +26,14 @@ export const handleRankingReorder = (
     newIndex = localRankings.findIndex(p => p.id === overPokemonId);
     console.log(`🚀 [ENHANCED_DRAG_END] Reordering to Pokemon ${overPokemonId} position`);
   } else if (positionIndex !== null) {
-    // Dropped on an empty position
-    if (positionIndex >= 0 && positionIndex <= localRankings.length) {
-      newIndex = Math.min(positionIndex, localRankings.length - 1); // Ensure we don't exceed bounds
-      console.log(`🚀 [ENHANCED_DRAG_END] Reordering to position slot ${positionIndex} -> ${newIndex}`);
+    // Dropped on an empty position - prefer droppable data index
+    const dataIndex = over.data?.current?.index;
+    const finalIndex = dataIndex !== undefined ? dataIndex : positionIndex;
+    if (finalIndex >= 0 && finalIndex <= localRankings.length) {
+      newIndex = Math.min(finalIndex, localRankings.length - 1); // Ensure we don't exceed bounds
+      console.log(
+        `🚀 [ENHANCED_DRAG_END] Reordering to position slot ${finalIndex} (from ${dataIndex !== undefined ? 'data' : 'id'}) -> ${newIndex}`
+      );
     }
   }
   

--- a/src/hooks/ranking/utils/idParsing.ts
+++ b/src/hooks/ranking/utils/idParsing.ts
@@ -10,14 +10,16 @@ export const parseId = (id: string): ParsedId => {
     const pokemonId = parseInt(id.replace('available-', ''), 10);
     return { pokemonId: isNaN(pokemonId) ? null : pokemonId, positionIndex: null };
   }
-  if (id.startsWith('ranking-position-')) {
-    const positionIndex = parseInt(id.replace('ranking-position-', ''), 10);
-    return { pokemonId: null, positionIndex: isNaN(positionIndex) ? null : positionIndex };
+
+  const rankingMatch = id.match(/^ranking-(?:position-)?(\d+)$/);
+  if (rankingMatch) {
+    const value = parseInt(rankingMatch[1], 10);
+    if (id.includes('position-')) {
+      return { pokemonId: null, positionIndex: isNaN(value) ? null : value };
+    }
+    return { pokemonId: isNaN(value) ? null : value, positionIndex: null };
   }
-  if (id.startsWith('ranking-')) {
-    const pokemonId = parseInt(id.replace('ranking-', ''), 10);
-    return { pokemonId: isNaN(pokemonId) ? null : pokemonId, positionIndex: null };
-  }
+
   // Legacy numeric IDs
   const numeric = parseInt(id, 10);
   return { pokemonId: isNaN(numeric) ? null : numeric, positionIndex: null };


### PR DESCRIPTION
## Summary
- align droppable IDs with sortable item IDs
- extend id parsing to understand `ranking-position-*`
- validate drops using regex for both pokemon and position ids
- use droppable data index when inserting with empty slots

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68417d38580c8333bb3e0cae3bee13f8