### PR TITLE
Enable adding Pokémon via enhanced reorder

### DIFF
--- a/src/hooks/battle/useManualReorderCore.ts
+++ b/src/hooks/battle/useManualReorderCore.ts
@@ -177,7 +177,8 @@ export const useManualReorderCore = (
   const handleEnhancedManualReorder = useCallback((
     draggedPokemonId: number,
     sourceIndex: number,
-    destinationIndex: number
+    destinationIndex: number,
+      pokemon?: RankedPokemon
   ) => {
     const enhancedId = Date.now();
     console.log(`🎯 [MANUAL_REORDER_CORE_${enhancedId}] ===== ENHANCED MANUAL REORDER =====`);
@@ -189,18 +190,31 @@ export const useManualReorderCore = (
       console.error(`❌ [MANUAL_REORDER_CORE_${enhancedId}] No valid rankings available!`);
       return;
     }
-    
+
+    if (sourceIndex === -1) {
+      if (!pokemon) {
+        console.error(`❌ [MANUAL_REORDER_CORE_${enhancedId}] Pokemon object required when sourceIndex is -1`);
+        return;
+      }
+      const newRankings = [...currentRankings];
+      newRankings.splice(destinationIndex, 0, pokemon);
+      stableRankingsRef.current = newRankings;
+      setLocalRankings(newRankings);
+      setTimeout(() => onRankingsUpdate(newRankings), 0);
+      return;
+    }
+
     if (sourceIndex < 0 || sourceIndex >= currentRankings.length) {
       console.error(`❌ [MANUAL_REORDER_CORE_${enhancedId}] Invalid source index: ${sourceIndex}`);
       return;
     }
-    
+
     const movedPokemon = currentRankings[sourceIndex];
     if (!movedPokemon) {
       console.error(`❌ [MANUAL_REORDER_CORE_${enhancedId}] Pokemon not found at source index`);
       return;
     }
-    
+
     processReorder(currentRankings, sourceIndex, destinationIndex, movedPokemon);
   }, []); // CRITICAL: Empty deps
 

--- a/src/hooks/ranking/handlers/availableToDragHandler.ts
+++ b/src/hooks/ranking/handlers/availableToDragHandler.ts
@@ -9,7 +9,12 @@ export const handleAvailableToRankingsDrop = (
   enhancedAvailablePokemon: any[],
   localRankings: any[],
   updateRating: (id: string, rating: Rating) => void,
-  handleEnhancedManualReorder: (pokemonId: number, sourceIndex: number, destinationIndex: number) => void,
+  handleEnhancedManualReorder: (
+    pokemonId: number,
+    sourceIndex: number,
+    destinationIndex: number,
+    pokemon?: any
+  ) => void,
   triggerReRanking: (pokemonId: number) => Promise<void>
 ) => {
   console.log(`🚀 [ENHANCED_DRAG_END] Available Pokemon ${pokemonId} dragged to ${overId}`);
@@ -87,7 +92,7 @@ export const handleAvailableToRankingsDrop = (
     console.log(`🔥 [ADD_NEW_POKEMON] Final insertion position: ${insertionPosition}`);
     
     try {
-      handleEnhancedManualReorder(pokemonId, -1, insertionPosition);
+      handleEnhancedManualReorder(pokemonId, -1, insertionPosition, pokemon);
       console.log(`🔥 [ADD_NEW_POKEMON] Successfully added ${pokemon.name}`);
     } catch (error) {
       console.error(`🔥 [ADD_NEW_POKEMON] Failed to add Pokemon:`, error);

--- a/src/hooks/ranking/handlers/dragEndHandler.ts
+++ b/src/hooks/ranking/handlers/dragEndHandler.ts
@@ -10,7 +10,12 @@ export const useDragEndHandler = (
   enhancedAvailablePokemon: any[],
   localRankings: any[],
   updateRating: (id: string, rating: Rating) => void,
-  handleEnhancedManualReorder: (pokemonId: number, sourceIndex: number, destinationIndex: number) => void,
+  handleEnhancedManualReorder: (
+    pokemonId: number,
+    sourceIndex: number,
+    destinationIndex: number,
+    pokemon?: any
+  ) => void,
   triggerReRanking: (pokemonId: number) => Promise<void>,
   setActiveDraggedPokemon: (pokemon: any) => void
 ) => {

--- a/src/hooks/ranking/handlers/reorderHandler.ts
+++ b/src/hooks/ranking/handlers/reorderHandler.ts
@@ -6,7 +6,12 @@ export const handleRankingReorder = (
   overId: string,
   over: any,
   localRankings: any[],
-  handleEnhancedManualReorder: (pokemonId: number, sourceIndex: number, destinationIndex: number) => void
+  handleEnhancedManualReorder: (
+    pokemonId: number,
+    sourceIndex: number,
+    destinationIndex: number,
+    pokemon?: any
+  ) => void
 ) => {
   const { pokemonId: activePokemonId } = parseId(activeId);
   

--- a/src/hooks/ranking/useEnhancedRankingDragDrop.ts
+++ b/src/hooks/ranking/useEnhancedRankingDragDrop.ts
@@ -8,7 +8,12 @@ export const useEnhancedRankingDragDrop = (
   enhancedAvailablePokemon: any[],
   localRankings: any[],
   setAvailablePokemon: React.Dispatch<React.SetStateAction<any[]>>,
-  handleEnhancedManualReorder: (pokemonId: number, sourceIndex: number, destinationIndex: number) => void,
+  handleEnhancedManualReorder: (
+    pokemonId: number,
+    sourceIndex: number,
+    destinationIndex: number,
+    pokemon?: any
+  ) => void,
   triggerReRanking: (pokemonId: number) => Promise<void>
 ) => {
   const [activeDraggedPokemon, setActiveDraggedPokemon] = useState<any>(null);

--- a/src/hooks/ranking/useRankingDragDrop.ts
+++ b/src/hooks/ranking/useRankingDragDrop.ts
@@ -8,7 +8,12 @@ export const useRankingDragDrop = (
   availablePokemon: any[],
   localRankings: any[],
   setAvailablePokemon: React.Dispatch<React.SetStateAction<any[]>>,
-  handleEnhancedManualReorder: (pokemonId: number, sourceIndex: number, destinationIndex: number) => void
+  handleEnhancedManualReorder: (
+    pokemonId: number,
+    sourceIndex: number,
+    destinationIndex: number,
+    pokemon?: any
+  ) => void
 ) => {
   const [activeDraggedPokemon, setActiveDraggedPokemon] = useState<any>(null);
   const { updateRating } = useTrueSkillStore();
@@ -114,7 +119,7 @@ export const useRankingDragDrop = (
           
           // Call enhanced manual reorder but with special handling for new additions
           // We use -1 as source index to indicate this is a new addition (not a reorder)
-          handleEnhancedManualReorder(pokemonId, -1, insertionPosition);
+          handleEnhancedManualReorder(pokemonId, -1, insertionPosition, pokemon);
           console.log(`🔥🔥🔥 [MANUAL_ADD_SINGLE_POKEMON] ✅ Enhanced manual reorder called for single Pokemon addition`);
           
           // Dispatch a specific event for single Pokemon addition (not full sync)


### PR DESCRIPTION
## Summary
- allow `handleEnhancedManualReorder` to optionally accept a Pokémon
- insert Pokémon when `sourceIndex` is `-1`
- pass the Pokémon when adding from the available list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841994a35b483338e10f328b3ad2984