### PR TITLE
Fix rankings drop zone

### DIFF
--- a/src/components/ranking/RankingsDroppableContainer.tsx
+++ b/src/components/ranking/RankingsDroppableContainer.tsx
@@ -8,7 +8,7 @@ interface RankingsDroppableContainerProps {
 
 export const RankingsDroppableContainer: React.FC<RankingsDroppableContainerProps> = ({ children }) => {
   const { setNodeRef, isOver } = useDroppable({
-    id: 'rankings-drop-zone',
+    id: 'rankings-container-drop-zone',
     data: {
       type: 'rankings-container',
       accepts: ['available-pokemon'],
@@ -16,7 +16,7 @@ export const RankingsDroppableContainer: React.FC<RankingsDroppableContainerProp
     },
   });
 
-  console.log(`🎯 [DROPPABLE_CONTAINER] Rankings drop zone initialized with ID: rankings-drop-zone`);
+  console.log(`🎯 [DROPPABLE_CONTAINER] Rankings drop zone initialized with ID: rankings-container-drop-zone`);
   console.log(`🎯 [DROPPABLE_CONTAINER] Drop zone isOver: ${isOver}`);
 
   return (

--- a/src/hooks/ranking/useEnhancedRankingDragDrop.ts
+++ b/src/hooks/ranking/useEnhancedRankingDragDrop.ts
@@ -66,7 +66,8 @@ export const useEnhancedRankingDragDrop = (
       
       // Check for valid drop targets
       const isValidDropTarget = (
-        overId === 'rankings-drop-zone' || 
+        overId === 'rankings-drop-zone' ||
+        overId === 'rankings-container-drop-zone' ||
         overId === 'rankings-grid-drop-zone' ||
         over.data?.current?.type === 'rankings-container' ||
         over.data?.current?.type === 'rankings-grid' ||
@@ -80,7 +81,7 @@ export const useEnhancedRankingDragDrop = (
       console.log(`🚀🚀🚀 [ENHANCED_DRAG_END] Drop target validation: ${isValidDropTarget}`);
       console.log(`🚀🚀🚀 [ENHANCED_DRAG_END] Drop target details:`, {
         overId,
-        isRankingsDropZone: overId === 'rankings-drop-zone',
+        isRankingsDropZone: overId === 'rankings-drop-zone' || overId === 'rankings-container-drop-zone',
         isRankingsGridDropZone: overId === 'rankings-grid-drop-zone',
         overDataType: over.data?.current?.type,
         overDataAccepts: over.data?.current?.accepts,

--- a/src/hooks/ranking/useRankingDragDrop.ts
+++ b/src/hooks/ranking/useRankingDragDrop.ts
@@ -58,7 +58,8 @@ export const useRankingDragDrop = (
       // Check for valid drop targets
       const isValidDropTarget = (
         // Direct drop zone IDs
-        overId === 'rankings-drop-zone' || 
+        overId === 'rankings-drop-zone' ||
+        overId === 'rankings-container-drop-zone' ||
         overId === 'rankings-grid-drop-zone' ||
         // Drop zone data types
         over.data?.current?.type === 'rankings-container' ||


### PR DESCRIPTION
## Summary
- ensure unique droppable id for rankings container
- recognize the new drop zone in drag/drop handlers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841b7b9dec48333872a938b3f6c22c3