### PR TITLE
Refactor ranking context

### DIFF
--- a/src/components/battle/DragDropGridMemoized.tsx
+++ b/src/components/battle/DragDropGridMemoized.tsx
@@ -2,10 +2,6 @@
 import React, { useMemo } from "react";
 import { Pokemon, RankedPokemon } from "@/services/pokemon";
 import OptimizedDraggableCard from "./OptimizedDraggableCard";
-import {
-  SortableContext,
-  rectSortingStrategy,
-} from '@dnd-kit/sortable';
 
 interface DragDropGridMemoizedProps {
   displayRankings: (Pokemon | RankedPokemon)[];
@@ -26,13 +22,6 @@ const DragDropGridMemoized: React.FC<DragDropGridMemoizedProps> = React.memo(({
   console.log('🎨 [GRID_DEBUG] displayRankings length:', displayRankings.length);
   console.log('🎨 [GRID_DEBUG] onManualReorder exists:', !!onManualReorder);
 
-  // Create sortable items for proper drag behavior
-  const sortableItems = useMemo(() => {
-    const items = displayRankings.map(p => `ranking-${p.id}`);
-    console.log(`🎨 [GRID_DEBUG] Sortable items created:`, items.slice(0, 5));
-    console.log(`🎨 [GRID_DEBUG] Total items: ${items.length}`);
-    return items;
-  }, [displayRankings]);
 
   // Create cards with proper sortable integration
   const renderedCards = useMemo(() => {
@@ -58,20 +47,15 @@ const DragDropGridMemoized: React.FC<DragDropGridMemoizedProps> = React.memo(({
     });
   }, [displayRankings, localPendingRefinements]);
 
-  console.log(`🎨 [GRID_DEBUG] Rendering ${renderedCards.length} cards in SortableContext`);
+  console.log(`🎨 [GRID_DEBUG] Rendering ${renderedCards.length} cards in grid`);
 
   return (
-    <SortableContext 
-      items={sortableItems}
-      strategy={rectSortingStrategy}
+    <div
+      className="grid gap-4"
+      style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))' }}
     >
-      <div 
-        className="grid gap-4" 
-        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))' }}
-      >
-        {renderedCards}
-      </div>
-    </SortableContext>
+      {renderedCards}
+    </div>
   );
 });
 

--- a/src/components/ranking/EnhancedRankingLayout.tsx
+++ b/src/components/ranking/EnhancedRankingLayout.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect } from "react";
 import { DndContext, DragOverlay, closestCorners, useSensor, useSensors, PointerSensor, KeyboardSensor } from '@dnd-kit/core';
-import { SortableContext, verticalListSortingStrategy, rectSortingStrategy, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { useTrueSkillStore } from "@/stores/trueskillStore";
 import { BattleType } from "@/hooks/battle/types";
 import { LoadingType } from "@/hooks/pokemon/types";
@@ -115,10 +115,8 @@ export const EnhancedRankingLayout: React.FC<EnhancedRankingLayoutProps> = React
 
   // CRITICAL FIX: Create sortable IDs for proper context separation
   const rankedPokemonIds = manualRankingOrder.map(pokemon => `ranking-${pokemon.id}`);
-  const availablePokemonIds = enhancedAvailablePokemon.map(pokemon => `available-${pokemon.id}`);
 
   console.log(`🎯 [SORTABLE_CONTEXT] Ranked Pokemon IDs:`, rankedPokemonIds.slice(0, 3));
-  console.log(`🎯 [SORTABLE_CONTEXT] Available Pokemon IDs:`, availablePokemonIds.slice(0, 3));
 
   // CRITICAL FIX: Enhanced collision detection and debug logging
   const debugOnDragStart = (event: any) => {
@@ -224,34 +222,29 @@ export const EnhancedRankingLayout: React.FC<EnhancedRankingLayoutProps> = React
         >
           <div className="grid md:grid-cols-2 gap-4" style={{ height: 'calc(100vh - 12rem)' }}>
             <Card className="shadow-lg border border-gray-200 overflow-hidden flex flex-col">
-              {/* CRITICAL FIX: Separate SortableContext for available Pokemon */}
-              <SortableContext items={availablePokemonIds} strategy={rectSortingStrategy}>
-                <EnhancedAvailablePokemonSection
-                  enhancedAvailablePokemon={enhancedAvailablePokemon}
-                  isLoading={isLoading}
-                  selectedGeneration={selectedGeneration}
-                  loadingType={loadingType}
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  loadingRef={loadingRef}
-                  handlePageChange={handlePageChange}
-                  getPageRange={getPageRange}
-                />
-              </SortableContext>
+              <EnhancedAvailablePokemonSection
+                enhancedAvailablePokemon={enhancedAvailablePokemon}
+                isLoading={isLoading}
+                selectedGeneration={selectedGeneration}
+                loadingType={loadingType}
+                currentPage={currentPage}
+                totalPages={totalPages}
+                loadingRef={loadingRef}
+                handlePageChange={handlePageChange}
+                getPageRange={getPageRange}
+              />
             </Card>
 
             <Card className="shadow-lg border border-gray-200 overflow-hidden flex flex-col">
               <RankingsDroppableContainer>
-                {/* CRITICAL FIX: Separate SortableContext for ranked Pokemon */}
-                <SortableContext items={rankedPokemonIds} strategy={verticalListSortingStrategy}>
-                  <RankingsSectionStable
-                    displayRankings={manualRankingOrder}
-                    onManualReorder={stableOnManualReorder}
-                    onLocalReorder={stableOnLocalReorder}
-                    pendingRefinements={new Set()}
-                    availablePokemon={enhancedAvailablePokemon}
-                  />
-                </SortableContext>
+                <RankingsSectionStable
+                  displayRankings={manualRankingOrder}
+                  sortableItems={rankedPokemonIds}
+                  onManualReorder={stableOnManualReorder}
+                  onLocalReorder={stableOnLocalReorder}
+                  pendingRefinements={new Set()}
+                  availablePokemon={enhancedAvailablePokemon}
+                />
               </RankingsDroppableContainer>
             </Card>
           </div>

--- a/src/components/ranking/RankingsSectionStable.tsx
+++ b/src/components/ranking/RankingsSectionStable.tsx
@@ -8,7 +8,16 @@ import { useDroppable } from '@dnd-kit/core';
 
 interface RankingsSectionStableProps {
   displayRankings: (Pokemon | RankedPokemon)[];
-  onManualReorder?: (draggedPokemonId: number, sourceIndex: number, destinationIndex: number) => void;
+  /**
+   * IDs for the SortableContext. These should be prefixed with
+   * `ranking-` to match dnd-kit sortable expectations.
+   */
+  sortableItems: string[];
+  onManualReorder?: (
+    draggedPokemonId: number,
+    sourceIndex: number,
+    destinationIndex: number
+  ) => void;
   onLocalReorder?: (newRankings: (Pokemon | RankedPokemon)[]) => void;
   pendingRefinements?: Set<number>;
   availablePokemon?: any[];
@@ -16,6 +25,7 @@ interface RankingsSectionStableProps {
 
 export const RankingsSectionStable: React.FC<RankingsSectionStableProps> = React.memo(({
   displayRankings,
+  sortableItems,
   onManualReorder,
   onLocalReorder,
   pendingRefinements = new Set<number>(),
@@ -30,13 +40,6 @@ export const RankingsSectionStable: React.FC<RankingsSectionStableProps> = React
     onLocalReorder
   );
 
-  // Create sortable items with consistent ranking- prefix
-  const sortableItems = useMemo(() => {
-    const items = displayRankings.map(pokemon => `ranking-${pokemon.id}`);
-    console.log(`🎯 [SORTABLE_DEBUG] SortableContext Items:`, items.slice(0, 5));
-    console.log(`🎯 [SORTABLE_DEBUG] Total sortable items: ${items.length}`);
-    return items;
-  }, [displayRankings]);
 
   // CRITICAL FIX: Setup droppable for the entire rankings area with explicit collision detection
   const { setNodeRef: setDroppableRef, isOver } = useDroppable({


### PR DESCRIPTION
## Summary
- remove nested SortableContext from DragDropGridMemoized
- eliminate extra SortableContext wrappers in EnhancedRankingLayout
- pass sortable item ids into RankingsSectionStable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6841f57b140083338b14029211ae77e6