### PR TITLE
Adjust manual reorder for large datasets

### DIFF
--- a/src/components/battle/DraggableMilestoneView.tsx
+++ b/src/components/battle/DraggableMilestoneView.tsx
@@ -70,7 +70,8 @@ const DraggableMilestoneView: React.FC<DraggableMilestoneViewProps> = React.memo
           isManualOperationInProgress,
           manualOperationTimestamp,
           handleEnhancedManualReorder,
-          stableOnLocalReorder
+          stableOnLocalReorder,
+          tooLarge
         }) => (
           <>
             <MilestoneDebugLogger
@@ -85,6 +86,7 @@ const DraggableMilestoneView: React.FC<DraggableMilestoneViewProps> = React.memo
               displayRankings={displayRankings.slice(0, Math.min(milestoneDisplayCount, maxItems))}
               handleEnhancedManualReorder={handleEnhancedManualReorder}
               stableOnLocalReorder={stableOnLocalReorder}
+              disabled={tooLarge}
             >
               <DragDropGridMemoized
                 displayRankings={displayRankings.slice(0, Math.min(milestoneDisplayCount, maxItems))}

--- a/src/components/battle/MilestoneDragProvider.tsx
+++ b/src/components/battle/MilestoneDragProvider.tsx
@@ -8,6 +8,7 @@ interface MilestoneDragProviderProps {
   displayRankings: (Pokemon | RankedPokemon)[];
   handleEnhancedManualReorder: (draggedPokemonId: number, sourceIndex: number, destinationIndex: number) => void;
   stableOnLocalReorder: (newRankings: any[]) => void;
+  disabled?: boolean;
   children: React.ReactNode;
 }
 
@@ -15,17 +16,20 @@ const MilestoneDragProvider: React.FC<MilestoneDragProviderProps> = ({
   displayRankings,
   handleEnhancedManualReorder,
   stableOnLocalReorder,
+  disabled = false,
   children
 }) => {
   // Drag and drop handling
-  const { sensors, handleDragEnd } = useRankingDragDrop({
-    localRankings: displayRankings,
-    onManualReorder: (draggedPokemonId: number, sourceIndex: number, destinationIndex: number) => {
-      console.log(`🏆 [MILESTONE_DRAG_PROVIDER] Drag completed: ${draggedPokemonId} from ${sourceIndex} to ${destinationIndex}`);
-      handleEnhancedManualReorder(draggedPokemonId, sourceIndex, destinationIndex);
-    },
-    onLocalReorder: stableOnLocalReorder,
-  });
+  const { sensors, handleDragEnd } = disabled
+    ? { sensors: [], handleDragEnd: () => {} }
+    : useRankingDragDrop({
+        localRankings: displayRankings,
+        onManualReorder: (draggedPokemonId: number, sourceIndex: number, destinationIndex: number) => {
+          console.log(`🏆 [MILESTONE_DRAG_PROVIDER] Drag completed: ${draggedPokemonId} from ${sourceIndex} to ${destinationIndex}`);
+          handleEnhancedManualReorder(draggedPokemonId, sourceIndex, destinationIndex);
+        },
+        onLocalReorder: stableOnLocalReorder,
+      });
 
   return (
     <DndContext

--- a/src/components/battle/MilestoneStateManager.tsx
+++ b/src/components/battle/MilestoneStateManager.tsx
@@ -102,7 +102,7 @@ const MilestoneStateManager: React.FC<MilestoneStateManagerProps> = ({
   }, [formattedRankings, isManualOperationInProgress, manualOperationTimestamp, localRankings]);
 
   // CRITICAL DEBUG: Enhanced manual reorder with detailed logging
-  const { handleEnhancedManualReorder } = useEnhancedManualReorder(
+  const { handleEnhancedManualReorder, tooLarge } = useEnhancedManualReorder(
     localRankings as RankedPokemon[],
     (updatedRankings: RankedPokemon[]) => {
       const reorderId = Date.now();
@@ -149,6 +149,7 @@ const MilestoneStateManager: React.FC<MilestoneStateManagerProps> = ({
         displayRankings,
         isManualOperationInProgress,
         manualOperationTimestamp,
+        tooLarge,
         handleEnhancedManualReorder,
         stableOnLocalReorder
       })}

--- a/src/components/ranking/RankingUICore.tsx
+++ b/src/components/ranking/RankingUICore.tsx
@@ -64,7 +64,7 @@ export const RankingUICore: React.FC<RankingUICoreProps> = React.memo(({
 
   // Enhanced manual reorder with manual order preservation and direct TrueSkill updates
   // EXPLICIT NOTE: Removed addImpliedBattle parameter - no longer using implied battles
-  const { handleEnhancedManualReorder } = useEnhancedManualReorder(
+  const { handleEnhancedManualReorder, tooLarge } = useEnhancedManualReorder(
     localRankings,
     updateLocalRankings,
     true, // preventAutoResorting for Manual Mode
@@ -103,7 +103,7 @@ export const RankingUICore: React.FC<RankingUICoreProps> = React.memo(({
     availablePokemon: enhancedAvailablePokemon,
     localRankings,
     setAvailablePokemon,
-    onManualReorder: handleEnhancedManualReorder,
+    onManualReorder: tooLarge ? (() => {}) : handleEnhancedManualReorder,
     triggerReRanking,
   });
 

--- a/src/components/rankings/PersonalRankingsView.tsx
+++ b/src/components/rankings/PersonalRankingsView.tsx
@@ -108,7 +108,7 @@ const PersonalRankingsView: React.FC<PersonalRankingsViewProps> = ({
   }, []);
 
   // Use the same enhanced manual reorder hook as Manual mode
-  const { handleEnhancedManualReorder } = useEnhancedManualReorder(
+  const { handleEnhancedManualReorder, tooLarge } = useEnhancedManualReorder(
     localRankings,
     handleRankingsUpdate,
     true // Prevent auto-resorting during drag operations
@@ -197,7 +197,7 @@ const PersonalRankingsView: React.FC<PersonalRankingsViewProps> = ({
             displayRankings={displayRankings}
             localPendingRefinements={localPendingRefinements}
             pendingBattleCounts={new Map()}
-            onManualReorder={handleEnhancedManualReorder}
+            onManualReorder={tooLarge ? (() => {}) : handleEnhancedManualReorder}
             onLocalReorder={handleLocalReorder}
             onMarkAsPending={() => {}} // Not needed for rankings view
             availablePokemon={[]} // Not needed for rankings view

--- a/src/hooks/battle/useBattleManualReorder.ts
+++ b/src/hooks/battle/useBattleManualReorder.ts
@@ -18,7 +18,7 @@ export const useBattleManualReorder = (
   console.log(`🎯 [BATTLE_MANUAL_REORDER] EXPLICIT NOTE: Implied battles permanently removed`);
 
   // Use the enhanced manual reorder hook with direct TrueSkill updates
-  const { handleEnhancedManualReorder } = useEnhancedManualReorder(
+  const { handleEnhancedManualReorder, tooLarge } = useEnhancedManualReorder(
     finalRankings,
     onRankingsUpdate,
     isMilestoneView, // Prevent auto-resorting during milestone views
@@ -36,6 +36,11 @@ export const useBattleManualReorder = (
     console.log(`🎯 [BATTLE_MANUAL_REORDER] Will prevent auto-resorting: ${isMilestoneView}`);
     console.log(`🎯 [BATTLE_MANUAL_REORDER] Using direct TrueSkill updates instead of implied battles`);
 
+    if (tooLarge) {
+      console.warn(`🎯 [BATTLE_MANUAL_REORDER] Dataset too large - manual reorder disabled`);
+      return;
+    }
+
     if (!handleEnhancedManualReorder) {
       console.error(`🎯 [BATTLE_MANUAL_REORDER] ❌ No enhanced manual reorder function available!`);
       return;
@@ -48,7 +53,7 @@ export const useBattleManualReorder = (
     } catch (error) {
       console.error(`🎯 [BATTLE_MANUAL_REORDER] ❌ Error in enhanced manual reorder:`, error);
     }
-  }, [handleEnhancedManualReorder, isMilestoneView]);
+  }, [handleEnhancedManualReorder, isMilestoneView, tooLarge]);
 
   console.log(`🎯 [BATTLE_MANUAL_REORDER] Hook created, returning handleManualReorder function`);
   

--- a/src/hooks/battle/useManualReorderCore.ts
+++ b/src/hooks/battle/useManualReorderCore.ts
@@ -17,22 +17,17 @@ export const useManualReorderCore = (
   console.log(`🎯 [MANUAL_REORDER_CORE_${hookId}] EXPLICIT NOTE: Implied battles permanently removed`);
   console.log(`🎯 [MANUAL_REORDER_CORE_${hookId}] EXPLICIT NOTE: Immediate TrueSkill updates explicitly removed`);
 
-  // Early bailout for large datasets
-  if (finalRankings.length > 500) {
-    console.error('❌ Dataset too large for manual reorder. Please reduce the number of items.');
-    return {
-      displayRankings: finalRankings,
-      handleDragStart: () => {},
-      handleDragEnd: () => {},
-      handleEnhancedManualReorder: () => {},
-      isDragging: false,
-      isUpdating: false
-    };
+  const tooLarge = finalRankings.length > 500;
+
+  // Log when dataset is too large
+  if (tooLarge) {
+    console.error('❌ Dataset too large for manual reorder. Disabling drag handlers.');
   }
 
-  useRenderTracker('useManualReorderCore', { 
+  useRenderTracker('useManualReorderCore', {
     rankingsCount: finalRankings.length,
-    preventAutoResorting 
+    preventAutoResorting,
+    tooLarge
   });
 
   // CRITICAL FIX: Use completely stable state management
@@ -51,12 +46,13 @@ export const useManualReorderCore = (
 
   // Stable callbacks with no dependencies
   const handleDragStart = useCallback((event: any) => {
+    if (tooLarge) return;
     const draggedId = parseInt(event.active.id);
     isDraggingRef.current = true;
     draggedPokemonIdRef.current = draggedId;
     setRenderTrigger(prev => prev + 1);
     console.log('🎯 [DRAG_STATE] Drag started for Pokemon ID:', draggedId);
-  }, []);
+  }, [tooLarge]);
 
   const clearDragState = useCallback(() => {
     isDraggingRef.current = false;
@@ -75,6 +71,7 @@ export const useManualReorderCore = (
 
   // CRITICAL FIX: Only update when there's a real change and not during drag
   useEffect(() => {
+    if (tooLarge) return;
     if (isDraggingRef.current || isUpdatingRef.current) {
       console.log(`🎯 [MANUAL_REORDER_CORE_${hookId}] Skipping props update - dragging:${isDraggingRef.current}, updating:${isUpdatingRef.current}`);
       return;
@@ -97,6 +94,7 @@ export const useManualReorderCore = (
     newIndex: number,
     movedPokemon: RankedPokemon
   ) => {
+    if (tooLarge) return;
     const processId = Date.now();
     console.log(`🎯 [MANUAL_REORDER_CORE_${processId}] ===== PROCESSING REORDER =====`);
     console.log(`🎯 [MANUAL_REORDER_CORE_${processId}] EXPLICIT NOTE: No TrueSkill updates - visual reordering only`);
@@ -144,6 +142,7 @@ export const useManualReorderCore = (
   }, []); // CRITICAL: Empty deps to prevent re-creation
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
+    if (tooLarge) return;
     const dragId = Date.now();
     console.log(`🎯 [MANUAL_REORDER_CORE_${dragId}] ===== DRAG END HANDLER =====`);
     
@@ -172,13 +171,15 @@ export const useManualReorderCore = (
     console.log(`🎯 [MANUAL_REORDER_CORE_${dragId}] Moving ${movedPokemon.name} from ${oldIndex} to ${newIndex}`);
     
     processReorder(currentRankings, oldIndex, newIndex, movedPokemon);
-  }, []); // CRITICAL: Empty deps
+  }, [tooLarge]); // CRITICAL: Empty deps
 
-  const handleEnhancedManualReorder = useCallback((
-    draggedPokemonId: number,
-    sourceIndex: number,
-    destinationIndex: number
-  ) => {
+  const handleEnhancedManualReorder = useCallback(
+    (
+      draggedPokemonId: number,
+      sourceIndex: number,
+      destinationIndex: number
+    ) => {
+    if (tooLarge) return;
     const enhancedId = Date.now();
     console.log(`🎯 [MANUAL_REORDER_CORE_${enhancedId}] ===== ENHANCED MANUAL REORDER =====`);
     
@@ -202,10 +203,11 @@ export const useManualReorderCore = (
     }
     
     processReorder(currentRankings, sourceIndex, destinationIndex, movedPokemon);
-  }, []); // CRITICAL: Empty deps
+  }, [tooLarge]); // CRITICAL: Empty deps
 
   // Stable memoization
   const displayRankings = useMemo(() => {
+    if (tooLarge) return finalRankings;
     const source = localRankings.length > 0 ? localRankings : stableRankingsRef.current;
     const result = source.map((pokemon) => ({
       ...pokemon,
@@ -213,7 +215,7 @@ export const useManualReorderCore = (
     }));
     console.log(`🎯 [MANUAL_REORDER_CORE_${hookId}] displayRankings created from ${source.length} items`);
     return result;
-  }, [localRankings, renderTrigger, hookId]); // Include renderTrigger to update when drag state changes
+  }, [localRankings, renderTrigger, hookId, tooLarge, finalRankings]); // Include renderTrigger to update when drag state changes
 
   return {
     displayRankings,
@@ -221,6 +223,7 @@ export const useManualReorderCore = (
     handleDragEnd,
     handleEnhancedManualReorder,
     isDragging: isDraggingRef.current,
-    isUpdating: isUpdatingRef.current
+    isUpdating: isUpdatingRef.current,
+    tooLarge
   };
 };


### PR DESCRIPTION
## Summary
- prevent expensive manual reorder processing for datasets over 500 entries
- expose `tooLarge` flag from `useManualReorderCore`
- respect the flag in ranking and milestone components
- allow disabling drag provider when ranking list is large

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841faa1d5588333a26993cd9471a8d8