### PR TITLE
Fix refinement queue provider scope

### DIFF
--- a/src/components/BattleMode.tsx
+++ b/src/components/BattleMode.tsx
@@ -1,16 +1,11 @@
 
 import React from "react";
 import BattleModeCore from "./battle/BattleModeCore";
-import { RefinementQueueProvider } from "./battle/RefinementQueueProvider";
 
 const BattleMode = () => {
   console.log('🔥 BattleMode: Component rendering');
   
-  return (
-    <RefinementQueueProvider>
-      <BattleModeCore />
-    </RefinementQueueProvider>
-  );
+  return <BattleModeCore />;
 };
 
 export default BattleMode;

--- a/src/components/battle/BattleModeCore.tsx
+++ b/src/components/battle/BattleModeCore.tsx
@@ -3,7 +3,6 @@ import React, { useState, useCallback, useMemo, useEffect, useRef } from "react"
 import BattleModeLoader from "./BattleModeLoader";
 import BattleModeProvider from "./BattleModeProvider";
 import BattleModeContainer from "./BattleModeContainer";
-import { RefinementQueueProvider } from "./RefinementQueueProvider";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType, SingleBattle } from "@/hooks/battle/types";
 import { useTrueSkillStore } from "@/stores/trueskillStore";
@@ -11,7 +10,6 @@ import { useBattleDebugger } from "@/hooks/battle/useBattleDebugger";
 
 const BattleModeCore: React.FC = () => {
   console.log('[DEBUG BattleModeCore] Component rendering');
-  console.log(`🔄 [REFINEMENT_PROVIDER_TOP_LEVEL] Wrapping entire BattleMode with single RefinementQueueProvider`);
   
   // CRITICAL FIX: Use TrueSkill store as single source of truth for battle count
   const { totalBattles, isHydrated, waitForHydration, smartSync } = useTrueSkillStore();
@@ -108,7 +106,7 @@ const BattleModeCore: React.FC = () => {
     console.log(`🔒 [POKEMON_LOADING_FIX] BattleModeCore showing loading state - isLoading: ${isLoading}, Pokemon count: ${stablePokemon.length}`);
     
     return (
-      <RefinementQueueProvider>
+      <>
         <BattleModeLoader
           onPokemonLoaded={handlePokemonLoaded}
           onLoadingChange={handleLoadingChange}
@@ -119,12 +117,12 @@ const BattleModeCore: React.FC = () => {
             <p>Loading complete Pokémon dataset for battles...</p>
           </div>
         </div>
-      </RefinementQueueProvider>
+      </>
     );
   }
 
   return (
-    <RefinementQueueProvider>
+    <>
       <BattleModeLoader
         onPokemonLoaded={handlePokemonLoaded}
         onLoadingChange={handleLoadingChange}
@@ -137,7 +135,7 @@ const BattleModeCore: React.FC = () => {
           setBattleResults={stableSetBattleResults}
         />
       </BattleModeProvider>
-    </RefinementQueueProvider>
+    </>
   );
 };
 

--- a/src/components/battle/DragDropGrid.tsx
+++ b/src/components/battle/DragDropGrid.tsx
@@ -67,6 +67,7 @@ const DragDropGrid: React.FC<DragDropGridProps> = ({
                 isDraggable={true}
                 isAvailable={false}
                 context="ranked"
+                allRankedPokemon={displayRankings}
               />
             );
           })}

--- a/src/components/battle/DraggableMilestoneGrid.tsx
+++ b/src/components/battle/DraggableMilestoneGrid.tsx
@@ -89,6 +89,7 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
           isDraggable={!!onManualReorder}
           context="ranked"
           isPending={localPendingRefinements.has(pokemon.id)}
+          allRankedPokemon={displayRankings}
         />
       ))}
     </div>
@@ -128,6 +129,7 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
                 isDraggable={false}
                 context="ranked"
                 isPending={localPendingRefinements.has(activePokemon.id)}
+                allRankedPokemon={displayRankings}
               />
             </div>
           ) : null}

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -55,8 +55,8 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   
   // Check if this Pokemon has any battles in the refinement queue
   const isPendingRefinement = contextAvailable ? (
-    refinementQueue.some(battle => 
-      battle.primaryPokemonId === pokemon.id || battle.opponentPokemonId === pokemon.id
+    refinementQueue.some(
+      battle => battle.primaryPokemonId === pokemon.id
     ) || localPendingState
   ) : localPendingState;
 

--- a/src/components/pokemon/LazyPokemonGrid.tsx
+++ b/src/components/pokemon/LazyPokemonGrid.tsx
@@ -32,6 +32,11 @@ export const LazyPokemonGrid: React.FC<LazyPokemonGridProps> = ({
     containerHeight
   });
 
+  const rankedList = React.useMemo(
+    () => items.filter(i => i.type === 'pokemon').map(i => i.data),
+    [items]
+  );
+
   return (
     <div
       ref={scrollElementRef}
@@ -77,6 +82,7 @@ export const LazyPokemonGrid: React.FC<LazyPokemonGridProps> = ({
                     isDraggable={true}
                     isAvailable={!isRankingArea}
                     context={isRankingArea ? "ranked" : "available"}
+                    allRankedPokemon={isRankingArea ? rankedList : []}
                   />
                 );
               }

--- a/src/components/rankings/GlobalRankingsView.tsx
+++ b/src/components/rankings/GlobalRankingsView.tsx
@@ -221,6 +221,7 @@ const GlobalRankingsView: React.FC<GlobalRankingsViewProps> = ({
                 showRank={true}
                 isDraggable={false}
                 context="ranked"
+                allRankedPokemon={displayRankings}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- use shared refinement queue provider from `App` only
- supply ranking list to draggable cards in grids and rankings
- compute ranking list in lazy grid for star button
- show pending only for prioritized Pokemon

## Testing
- `npm run lint` *(fails: command not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684705e803c0833389b20ddfb05d8a35