### PR TITLE
Fix unresolved merge and refine star placement

### DIFF
--- a/src/components/BattleMode.tsx
+++ b/src/components/BattleMode.tsx
@@ -1,16 +1,11 @@
 
 import React from "react";
 import BattleModeCore from "./battle/BattleModeCore";
-import { RefinementQueueProvider } from "./battle/RefinementQueueProvider";
 
 const BattleMode = () => {
   console.log('🔥 BattleMode: Component rendering');
   
-  return (
-    <RefinementQueueProvider>
-      <BattleModeCore />
-    </RefinementQueueProvider>
-  );
+  return <BattleModeCore />;
 };
 
 export default BattleMode;

--- a/src/components/battle/BattleModeCore.tsx
+++ b/src/components/battle/BattleModeCore.tsx
@@ -3,7 +3,6 @@ import React, { useState, useCallback, useMemo, useEffect, useRef } from "react"
 import BattleModeLoader from "./BattleModeLoader";
 import BattleModeProvider from "./BattleModeProvider";
 import BattleModeContainer from "./BattleModeContainer";
-import { RefinementQueueProvider } from "./RefinementQueueProvider";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType, SingleBattle } from "@/hooks/battle/types";
 import { useTrueSkillStore } from "@/stores/trueskillStore";
@@ -11,7 +10,6 @@ import { useBattleDebugger } from "@/hooks/battle/useBattleDebugger";
 
 const BattleModeCore: React.FC = () => {
   console.log('[DEBUG BattleModeCore] Component rendering');
-  console.log(`🔄 [REFINEMENT_PROVIDER_TOP_LEVEL] Wrapping entire BattleMode with single RefinementQueueProvider`);
   
   // CRITICAL FIX: Use TrueSkill store as single source of truth for battle count
   const { totalBattles, isHydrated, waitForHydration, smartSync } = useTrueSkillStore();
@@ -108,7 +106,7 @@ const BattleModeCore: React.FC = () => {
     console.log(`🔒 [POKEMON_LOADING_FIX] BattleModeCore showing loading state - isLoading: ${isLoading}, Pokemon count: ${stablePokemon.length}`);
     
     return (
-      <RefinementQueueProvider>
+      <>
         <BattleModeLoader
           onPokemonLoaded={handlePokemonLoaded}
           onLoadingChange={handleLoadingChange}
@@ -119,12 +117,12 @@ const BattleModeCore: React.FC = () => {
             <p>Loading complete Pokémon dataset for battles...</p>
           </div>
         </div>
-      </RefinementQueueProvider>
+      </>
     );
   }
 
   return (
-    <RefinementQueueProvider>
+    <>
       <BattleModeLoader
         onPokemonLoaded={handlePokemonLoaded}
         onLoadingChange={handleLoadingChange}
@@ -137,7 +135,7 @@ const BattleModeCore: React.FC = () => {
           setBattleResults={stableSetBattleResults}
         />
       </BattleModeProvider>
-    </RefinementQueueProvider>
+    </>
   );
 };
 

--- a/src/components/battle/DragDropGrid.tsx
+++ b/src/components/battle/DragDropGrid.tsx
@@ -67,6 +67,7 @@ const DragDropGrid: React.FC<DragDropGridProps> = ({
                 isDraggable={true}
                 isAvailable={false}
                 context="ranked"
+                allRankedPokemon={displayRankings}
               />
             );
           })}

--- a/src/components/battle/DraggableMilestoneGrid.tsx
+++ b/src/components/battle/DraggableMilestoneGrid.tsx
@@ -89,6 +89,7 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
           isDraggable={!!onManualReorder}
           context="ranked"
           isPending={localPendingRefinements.has(pokemon.id)}
+          allRankedPokemon={displayRankings}
         />
       ))}
     </div>
@@ -128,6 +129,7 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
                 isDraggable={false}
                 context="ranked"
                 isPending={localPendingRefinements.has(activePokemon.id)}
+                allRankedPokemon={displayRankings}
               />
             </div>
           ) : null}

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
 import { Pokemon, RankedPokemon } from "@/services/pokemon";
 import { getPokemonBackgroundColor } from "./utils/PokemonColorUtils";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
@@ -48,15 +47,11 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
     typeof hasRefinementBattles === 'boolean'
   );
   
-  console.log(`🌟 [STAR_CLICK_TRACE] Pokemon ${pokemon.name} (${pokemon.id}):`);
-  console.log(`🌟 [STAR_CLICK_TRACE] - contextAvailable: ${contextAvailable}`);
-  console.log(`🌟 [STAR_CLICK_TRACE] - allRankedPokemon.length: ${allRankedPokemon.length}`);
-  console.log(`🌟 [STAR_CLICK_TRACE] - context: ${context}`);
   
   // Check if this Pokemon has any battles in the refinement queue
   const isPendingRefinement = contextAvailable ? (
-    refinementQueue.some(battle => 
-      battle.primaryPokemonId === pokemon.id || battle.opponentPokemonId === pokemon.id
+    refinementQueue.some(
+      battle => battle.primaryPokemonId === pokemon.id
     ) || localPendingState
   ) : localPendingState;
 
@@ -64,59 +59,43 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
     e.stopPropagation();
     e.preventDefault();
     
-    console.log(`🌟 [STAR_CLICK_DETAILED] ===== STAR CLICKED FOR ${pokemon.name} =====`);
-    
     if (!isPendingRefinement) {
-      console.log(`🌟 [STAR_CLICK_DETAILED] Adding ${pokemon.name} to refinement queue`);
       
       // Always set local pending state for immediate feedback
       setLocalPendingState(true);
       localStorage.setItem(`pokemon-pending-${pokemon.id}`, 'true');
       
-      // Only try to generate neighbor battles if we're in ranked context AND have sufficient ranked Pokemon
+      // Only try to generate random top 50 battles if we're in ranked context AND have ranked Pokemon
       if (context === 'ranked' && contextAvailable && allRankedPokemon.length > 1) {
-        console.log(`🌟 [STAR_CLICK_DETAILED] Context available and sufficient ranked Pokemon, generating neighbor battles`);
-        
+
         // Find current Pokemon's position in the ranked list
         const currentIndex = allRankedPokemon.findIndex(p => p.id === pokemon.id);
-        console.log(`🌟 [STAR_CLICK_DETAILED] Current index of ${pokemon.name}: ${currentIndex}`);
-        
+
         if (currentIndex >= 0) {
-          // Generate neighbor battles for this Pokemon
-          const neighbors: number[] = [];
-          
-          // Add Pokemon before current position
-          if (currentIndex > 0) {
-            neighbors.push(allRankedPokemon[currentIndex - 1].id);
+          // Pick three random opponents from the top 50 (excluding this Pokemon)
+          const topPool = allRankedPokemon
+            .slice(0, 50)
+            .filter(p => p.id !== pokemon.id);
+          const poolCopy = [...topPool];
+          const opponents: number[] = [];
+          while (opponents.length < 3 && poolCopy.length > 0) {
+            const rand = Math.floor(Math.random() * poolCopy.length);
+            const opponent = poolCopy.splice(rand, 1)[0];
+            opponents.push(opponent.id);
           }
-          // Add Pokemon after current position  
-          if (currentIndex < allRankedPokemon.length - 1) {
-            neighbors.push(allRankedPokemon[currentIndex + 1].id);
-          }
-          
-          console.log(`🌟 [STAR_CLICK_DETAILED] Final neighbors for ${pokemon.name}:`, neighbors);
-          
-          if (neighbors.length > 0) {
+
+
+
+          if (opponents.length > 0) {
             try {
-              queueBattlesForReorder(pokemon.id, neighbors, currentIndex);
-              console.log(`🌟 [STAR_CLICK_DETAILED] ✅ queueBattlesForReorder call completed successfully`);
+              queueBattlesForReorder(pokemon.id, opponents, currentIndex);
             } catch (error) {
-              console.error(`🌟 [STAR_CLICK_DETAILED] ❌ Error calling queueBattlesForReorder:`, error);
+              console.error('Error calling queueBattlesForReorder:', error);
             }
-          } else {
-            console.log(`🌟 [STAR_CLICK_DETAILED] ❌ No valid neighbors found`);
           }
-        } else {
-          console.log(`🌟 [STAR_CLICK_DETAILED] ❌ Pokemon not found in ranked list`);
         }
-      } else {
-        console.log(`🌟 [STAR_CLICK_DETAILED] ⚠️ Not in ranked context or insufficient Pokemon - just marking as pending`);
-        console.log(`🌟 [STAR_CLICK_DETAILED] - context: ${context}`);
-        console.log(`🌟 [STAR_CLICK_DETAILED] - contextAvailable: ${contextAvailable}`);
-        console.log(`🌟 [STAR_CLICK_DETAILED] - allRankedPokemon.length: ${allRankedPokemon.length}`);
       }
     } else {
-      console.log(`🌟 [STAR_CLICK_DETAILED] Pokemon ${pokemon.name} is already pending, toggling off`);
       setLocalPendingState(false);
       localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
     }
@@ -125,7 +104,6 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   // Clean up localStorage when Pokemon is actually processed in a battle
   React.useEffect(() => {
     if (contextAvailable && hasRefinementBattles === false && localPendingState) {
-      console.log(`🌟 [CLEANUP_TRACE] Clearing pending state for ${pokemon.name} - battles processed`);
       setLocalPendingState(false);
       localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
     }
@@ -223,17 +201,23 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       {/* Prioritize button - only for ranked context and when not dragging */}
       {!isDragging && context === 'ranked' && (
         <button
+          onPointerDown={(e) => {
+            // Prevent the drag listeners from capturing this interaction so
+            // the click event can fire reliably
+            e.stopPropagation();
+            e.preventDefault();
+          }}
           onClick={handlePrioritizeClick}
-          className={`absolute top-1 right-8 z-30 p-1 rounded-full group-hover:opacity-100 transition-opacity duration-200 ${
-            isPendingRefinement ? 'opacity-100' : 'opacity-25'
+          className={`absolute top-1/2 right-1 sm:right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-opacity duration-200 ${
+            isPendingRefinement ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
           }`}
           title="Prioritize for refinement battle"
           type="button"
         >
-          <Star 
-            className={`w-4 h-4 transition-all ${
+          <Star
+            className={`w-9 h-9 transition-all ${
               isPendingRefinement ? 'text-yellow-400 fill-yellow-400' : 'text-gray-500 hover:text-yellow-500'
-            }`} 
+            }`}
           />
         </button>
       )}

--- a/src/components/pokemon/LazyPokemonGrid.tsx
+++ b/src/components/pokemon/LazyPokemonGrid.tsx
@@ -32,6 +32,11 @@ export const LazyPokemonGrid: React.FC<LazyPokemonGridProps> = ({
     containerHeight
   });
 
+  const rankedList = React.useMemo(
+    () => items.filter(i => i.type === 'pokemon').map(i => i.data),
+    [items]
+  );
+
   return (
     <div
       ref={scrollElementRef}
@@ -77,6 +82,7 @@ export const LazyPokemonGrid: React.FC<LazyPokemonGridProps> = ({
                     isDraggable={true}
                     isAvailable={!isRankingArea}
                     context={isRankingArea ? "ranked" : "available"}
+                    allRankedPokemon={isRankingArea ? rankedList : []}
                   />
                 );
               }

--- a/src/components/rankings/GlobalRankingsView.tsx
+++ b/src/components/rankings/GlobalRankingsView.tsx
@@ -221,6 +221,7 @@ const GlobalRankingsView: React.FC<GlobalRankingsViewProps> = ({
                 showRank={true}
                 isDraggable={false}
                 context="ranked"
+                allRankedPokemon={displayRankings}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- remove leftover conflict markers and clean up star click handler
- keep star button bigger (`w-9 h-9`) and positioned toward the right side of the card
- randomize queued opponents from the top 50 when a star is clicked
- remove unused CSS import

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684705e803c0833389b20ddfb05d8a35