### PR TITLE
Add lint prerequisites docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ npm i
 npm run dev
 ```
 
+### Linting
+
+Before running `npm run lint`, make sure all dependencies are installed. Execute
+`npm install` (or `bun install`) once after cloning the repo so that ESLint and
+its plugins are available.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "node scripts/check-eslint.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/check-eslint.js
+++ b/scripts/check-eslint.js
@@ -1,0 +1,15 @@
+import { existsSync } from 'fs';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+try {
+  const eslintPath = require.resolve('@eslint/js/package.json');
+  if (!existsSync(eslintPath)) {
+    throw new Error('Not found');
+  }
+  console.log('@eslint/js detected at', eslintPath);
+} catch (err) {
+  console.error('Error: @eslint/js is not installed. Please run "npm install" or "bun install".');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- mention running `npm install` before `npm run lint`
- add simple postinstall script checking for `@eslint/js`

## Testing
- `npm run lint` *(fails: 323 errors, 73 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68477cf3c6448333b77dd8527f9cc078