### PR TITLE
Fix smart sync cloud update

### DIFF
--- a/src/components/battle/BattleInterface.tsx
+++ b/src/components/battle/BattleInterface.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, memo } from "react";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType } from "@/hooks/battle/types";
 import { useMilestoneCalculations } from "@/hooks/battle/useMilestoneCalculations";
+import { DEFAULT_BATTLE_MILESTONES } from "@/utils/battleMilestones";
 import { useBattleValidation } from "./BattleValidation";
 import { useBattleAnimationHandler } from "./BattleAnimationHandler";
 import { useBattleInteractionHandler } from "./BattleInteractionHandler";
@@ -44,9 +45,9 @@ const BattleInterface: React.FC<BattleInterfaceProps> = memo(({
   });
   
   // CRITICAL FIX: Use the correct milestones array or fallback to default
-  const actualMilestones = milestones && milestones.length > 0 
-    ? milestones 
-    : [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000];
+  const actualMilestones = milestones && milestones.length > 0
+    ? milestones
+    : DEFAULT_BATTLE_MILESTONES;
   
   console.log(`🎯 [MILESTONE_FIX] Using milestones:`, actualMilestones);
   

--- a/src/hooks/battle/useBattleMilestones.ts
+++ b/src/hooks/battle/useBattleMilestones.ts
@@ -1,8 +1,9 @@
 
 import { useCallback, useMemo } from "react";
+import { getDefaultBattleMilestones } from "@/utils/battleMilestones";
 
 export const useBattleMilestones = () => {
-  const milestones = useMemo(() => [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000], []);
+  const milestones = useMemo(() => getDefaultBattleMilestones(), []);
 
   const checkForMilestone = useCallback((newBattlesCompleted: number) => {
     console.log(`🏆🏆🏆 [MILESTONE_DETECTION] ===== Checking Milestone =====`);

--- a/src/hooks/battle/useBattleProgression.ts
+++ b/src/hooks/battle/useBattleProgression.ts
@@ -10,16 +10,18 @@ export const useBattleProgression = (
   milestones: number[],
   generateRankings: (results: any[]) => void
 ) => {
-  const { 
-    checkMilestone, 
+  const {
+    checkMilestone,
     isBattleGenerationBlocked,
     battleGenerationBlockedRef,
     resetMilestoneTracking,
-    triggerMilestone
+    triggerMilestone,
+    milestoneTracker
   } = useBattleProgressionMilestone(
     milestones,
     generateRankings,
-    setShowingMilestone
+    setShowingMilestone,
+    battlesCompleted
   );
 
   const { 
@@ -45,8 +47,8 @@ export const useBattleProgression = (
     console.log(`🔍 MISSED MILESTONE CHECK: Available milestones: ${milestones.join(', ')}`);
     
     // Find all milestones that should have been triggered by now
-    const missedMilestones = milestones.filter(milestone => 
-      currentBattleCount >= milestone
+    const missedMilestones = milestones.filter(milestone =>
+      currentBattleCount >= milestone && !milestoneTracker.current.has(milestone)
     );
     
     console.log(`🔍 MISSED MILESTONE CHECK: All eligible milestones: ${missedMilestones.join(', ')}`);
@@ -56,8 +58,7 @@ export const useBattleProgression = (
       const latestMissedMilestone = Math.max(...missedMilestones);
       console.log(`🎯 MISSED MILESTONE FOUND: Triggering latest milestone ${latestMissedMilestone}`);
       
-      // Force trigger the milestone view
-      setShowingMilestone(true);
+      // Force trigger the milestone view using centralized trigger
       return triggerMilestone(latestMissedMilestone, battleResults);
     }
     

--- a/src/hooks/battle/useBattleProgressionMilestone.ts
+++ b/src/hooks/battle/useBattleProgressionMilestone.ts
@@ -4,10 +4,18 @@ import { useCallback, useRef } from "react";
 export const useBattleProgressionMilestone = (
   milestones: number[],
   generateRankings: (results: any[]) => void,
-  setShowingMilestone: (value: boolean) => void
+  setShowingMilestone: (value: boolean) => void,
+  initialBattlesCompleted: number
 ) => {
-  const milestoneTracker = useRef<Set<number>>(new Set());
-  const lastTriggeredMilestoneRef = useRef<number | null>(null);
+  const milestoneTracker = useRef<Set<number>>(
+    new Set(milestones.filter(m => m <= initialBattlesCompleted))
+  );
+  const lastTriggeredMilestoneRef = useRef<number | null>(
+    (() => {
+      const reached = milestones.filter(m => m <= initialBattlesCompleted);
+      return reached.length > 0 ? reached[reached.length - 1] : null;
+    })()
+  );
   const battleGenerationBlockedRef = useRef(false);
 
   const checkMilestone = useCallback((newBattlesCompleted: number, battleResults: any[]): boolean => {

--- a/src/hooks/battle/useBattleStateData.ts
+++ b/src/hooks/battle/useBattleStateData.ts
@@ -1,5 +1,6 @@
 
 import { useState, useCallback } from "react";
+import { getDefaultBattleMilestones } from "@/utils/battleMilestones";
 import { Pokemon, RankedPokemon, TopNOption } from "@/services/pokemon";
 import { BattleType, SingleBattle } from "./types";
 import { formatPokemonName } from "@/utils/pokemon";
@@ -9,7 +10,7 @@ export const useBattleStateData = (
   initialSelectedGeneration: number
 ) => {
   // MILESTONE INVESTIGATION: Log initial milestones
-  const initialMilestones = [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000];
+  const initialMilestones = getDefaultBattleMilestones();
   console.log(`🔍🔍🔍 [MILESTONE_INVESTIGATION] useBattleStateData initializing with milestones:`, initialMilestones);
   
   // All state hooks - must be called unconditionally

--- a/src/hooks/battle/useBattleStateMilestoneEvents.ts
+++ b/src/hooks/battle/useBattleStateMilestoneEvents.ts
@@ -1,5 +1,6 @@
 
 import { useEffect, useCallback } from "react";
+import { DEFAULT_BATTLE_MILESTONES } from "@/utils/battleMilestones";
 import { Pokemon, RankedPokemon } from "@/services/pokemon";
 import { BattleType, SingleBattle } from "./types";
 
@@ -50,11 +51,11 @@ export const useBattleStateMilestoneEvents = ({
   
   // MILESTONE INVESTIGATION: Check where milestones came from
   console.log(`🔍🔍🔍 [MILESTONE_INVESTIGATION] useBattleStateMilestoneEvents received milestones:`, milestones);
-  console.log(`🔍🔍🔍 [MILESTONE_INVESTIGATION] Expected static milestones: [10,25,50,100,150,200,250,300,350,400,450,500,600,700,800,900,1000]`);
+  console.log(`🔍🔍🔍 [MILESTONE_INVESTIGATION] Expected static milestones: ${JSON.stringify(DEFAULT_BATTLE_MILESTONES)}`);
   
   // Check if milestones contains unexpected values
   if (Array.isArray(milestones)) {
-    const expectedMilestones = [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000];
+    const expectedMilestones = DEFAULT_BATTLE_MILESTONES;
     const hasUnexpectedMilestones = milestones.some(m => !expectedMilestones.includes(m));
     if (hasUnexpectedMilestones) {
       console.error(`🔍🔍🔍 [MILESTONE_INVESTIGATION] ❌ UNEXPECTED MILESTONES DETECTED!`);

--- a/src/hooks/battle/useBattleUIState.ts
+++ b/src/hooks/battle/useBattleUIState.ts
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from "react";
+import { getDefaultBattleMilestones } from "@/utils/battleMilestones";
 import { BattleType } from "./types";
 
 export const useBattleUIState = () => {
@@ -49,7 +50,7 @@ export const useBattleUIState = () => {
   
   // Milestone triggers - show rankings at these battle counts
   // Add more frequent early milestones, then cap at showing every 50 battles
-  const milestones = [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 850, 900, 950, 1000];
+  const milestones = getDefaultBattleMilestones();
 
   return {
     showingMilestone,

--- a/src/hooks/battle/useCompletionTracker.ts
+++ b/src/hooks/battle/useCompletionTracker.ts
@@ -1,5 +1,6 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
+import { getDefaultBattleMilestones } from "@/utils/battleMilestones";
 import { SingleBattle } from "./types";
 import { RankedPokemon } from "@/services/pokemon";
 
@@ -23,7 +24,7 @@ export const useCompletionTracker = (
   const lastCalculatedPercentageRef = useRef<number>(0);
 
   // Define milestones array locally to ensure consistency
-  const milestones = [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000];
+  const milestones = getDefaultBattleMilestones();
 
   useEffect(() => {
     showingMilestoneRef.current = showingMilestone;

--- a/src/hooks/battle/useMilestoneCalculations.ts
+++ b/src/hooks/battle/useMilestoneCalculations.ts
@@ -1,5 +1,6 @@
 
 import { useCallback } from "react";
+import { DEFAULT_BATTLE_MILESTONES } from "@/utils/battleMilestones";
 
 export const useMilestoneCalculations = (
   battlesCompleted: number,
@@ -8,7 +9,7 @@ export const useMilestoneCalculations = (
   battleHistory?: any[]
 ) => {
   // Handle both old signature (4 params) and new signature (2 params)
-  const actualMilestones = Array.isArray(milestones) ? milestones : [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000];
+  const actualMilestones = Array.isArray(milestones) ? milestones : DEFAULT_BATTLE_MILESTONES;
   const actualFinalRankings = finalRankings || [];
   const actualBattleHistory = battleHistory || [];
   const completionPercentage = typeof milestones === 'number' ? milestones : 0;

--- a/src/hooks/battle/useProgressState.ts
+++ b/src/hooks/battle/useProgressState.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { getDefaultBattleMilestones } from "@/utils/battleMilestones";
 
 export const useProgressState = () => {
   const [showingMilestone, setShowingMilestone] = useState(false);
@@ -8,7 +9,7 @@ export const useProgressState = () => {
   const [milestoneInProgress, setMilestoneInProgress] = useState(false);
   
   // CRITICAL FIX: Ensure milestones start with 10 and 25
-  const milestones = [10, 25, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, 700, 800, 900, 1000];
+  const milestones = getDefaultBattleMilestones();
   
   console.log("🎯 [MILESTONE_CONFIG] Milestones configured:", milestones);
   

--- a/src/utils/battleMilestones.ts
+++ b/src/utils/battleMilestones.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_BATTLE_MILESTONES: number[] = [
+  10,
+  25,
+  50,
+  100,
+  150,
+  200,
+  250,
+  300,
+  350,
+  400,
+  450,
+  500,
+  550,
+  600,
+  650,
+  700,
+  750,
+  800,
+  850,
+  900,
+  950,
+  1000
+];
+
+export const getDefaultBattleMilestones = (): number[] => [...DEFAULT_BATTLE_MILESTONES];


### PR DESCRIPTION
## Summary
- centralize milestone array in utils
- standardize milestone usage in all battle-related hooks and components
- initialize milestone tracking based on battles already completed to prevent spurious triggers

## Testing
- `npm run lint` *(fails: 322 errors, 73 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68476c675588833395b8aff3a6d277fc