### PR TITLE
Return milestone number when crossing threshold

### DIFF
--- a/src/hooks/battle/useBattleProgressionIncrement.ts
+++ b/src/hooks/battle/useBattleProgressionIncrement.ts
@@ -4,7 +4,10 @@ import { useCallback, useRef } from "react";
 export const useBattleProgressionIncrement = (
   battlesCompleted: number,
   setBattlesCompleted: React.Dispatch<React.SetStateAction<number>>,
-  checkMilestone: (newBattlesCompleted: number, battleResults: any[]) => boolean
+  checkMilestone: (
+    newBattlesCompleted: number,
+    battleResults: any[]
+  ) => number | null
 ) => {
   const incrementInProgressRef = useRef(false);
 
@@ -23,11 +26,13 @@ export const useBattleProgressionIncrement = (
     console.log(`✅ setBattlesCompleted called with: ${newBattleCount}`);
     
     const milestoneTriggered = checkMilestone(newBattleCount, battleResults);
-    
-    if (milestoneTriggered) {
-      console.log(`✅ MILESTONE SUCCESSFULLY TRIGGERED for battle ${newBattleCount}`);
+
+    if (milestoneTriggered !== null) {
+      console.log(
+        `✅ MILESTONE SUCCESSFULLY TRIGGERED: ${milestoneTriggered}`
+      );
       incrementInProgressRef.current = false;
-      return newBattleCount;
+      return milestoneTriggered;
     }
     
     incrementInProgressRef.current = false;

--- a/src/hooks/battle/useBattleProgressionMilestone.ts
+++ b/src/hooks/battle/useBattleProgressionMilestone.ts
@@ -28,7 +28,11 @@ export const useBattleProgressionMilestone = (
       reached.length > 0 ? reached[reached.length - 1] : null;
   }, [initialBattlesCompleted, milestones]);
 
-  const checkMilestone = useCallback((newBattlesCompleted: number, battleResults: any[]): boolean => {
+  const checkMilestone = useCallback(
+    (
+      newBattlesCompleted: number,
+      battleResults: any[]
+    ): number | null => {
     console.log(`🔍 MILESTONE CHECK: Checking ${newBattlesCompleted} battles against milestones: ${milestones.join(', ')}`);
     console.log(`🔍 MILESTONE CHECK: Already tracked milestones: ${Array.from(milestoneTracker.current).join(', ')}`);
     
@@ -52,22 +56,26 @@ export const useBattleProgressionMilestone = (
       lastTriggeredMilestoneRef.current = nextMilestone;
       
       try {
-        console.log(`🔵 useBattleProgression: Generating rankings for milestone ${nextMilestone}`);
+        console.log(
+          `🔵 useBattleProgression: Generating rankings for milestone ${nextMilestone}`
+        );
         generateRankings(battleResults);
         setShowingMilestone(true);
-        
-        console.log(`🚫 MILESTONE: Battle generation BLOCKED during milestone ${nextMilestone}`);
-        return true;
+
+        console.log(
+          `🚫 MILESTONE: Battle generation BLOCKED during milestone ${nextMilestone}`
+        );
+        return nextMilestone;
       } catch (err) {
         console.error("Error generating rankings at milestone:", err);
         // Reset flags on error
         milestoneTracker.current.delete(nextMilestone);
         battleGenerationBlockedRef.current = false;
-        return false;
+        return null;
       }
     }
 
-    return false;
+    return null;
   }, [milestones, generateRankings, setShowingMilestone]);
 
   const isBattleGenerationBlocked = useCallback(() => {


### PR DESCRIPTION
## Summary
- return the milestone number from `checkMilestone`
- forward that milestone number in `incrementBattlesCompleted`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68478cb7051c8333a001aadabde9ac89