### PR TITLE
Adjust star button on ranking cards

### DIFF
--- a/src/components/battle/BattleCardContainer.tsx
+++ b/src/components/battle/BattleCardContainer.tsx
@@ -10,6 +10,8 @@ import LoadingOverlay from "./LoadingOverlay";
 import BattleCardImage from "./BattleCardImage";
 import BattleCardInfo from "./BattleCardInfo";
 import BattleCardInteractions from "./BattleCardInteractions";
+import { Star } from "lucide-react";
+import { useSharedRefinementQueue } from "@/hooks/battle/useSharedRefinementQueue";
 
 interface BattleCardContainerProps {
   pokemon: Pokemon;
@@ -32,6 +34,30 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastClickTimeRef = useRef(0);
   const [isHovered, setIsHovered] = useState(false);
+
+  const [localPendingState, setLocalPendingState] = useState(() => {
+    const stored = localStorage.getItem(`pokemon-pending-${pokemon.id}`);
+    return stored === 'true';
+  });
+
+  const { refinementQueue, hasRefinementBattles } = useSharedRefinementQueue();
+
+  const contextAvailable = Boolean(
+    refinementQueue &&
+    Array.isArray(refinementQueue) &&
+    typeof hasRefinementBattles === 'boolean'
+  );
+
+  const isPendingRefinement = contextAvailable
+    ? refinementQueue.some(b => b.primaryPokemonId === pokemon.id) || localPendingState
+    : localPendingState;
+
+  useEffect(() => {
+    if (contextAvailable && hasRefinementBattles === false && localPendingState) {
+      setLocalPendingState(false);
+      localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
+    }
+  }, [contextAvailable, hasRefinementBattles, localPendingState, pokemon.id]);
 
   // Hooks for modal content - match manual mode approach
   const { flavorText, isLoadingFlavor } = usePokemonFlavorText(pokemon.id, isOpen);
@@ -97,6 +123,19 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
     setIsHovered(false);
   }, [displayName]);
 
+  const handlePrioritizeClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (!isPendingRefinement) {
+      setLocalPendingState(true);
+      localStorage.setItem(`pokemon-pending-${pokemon.id}`, 'true');
+    } else {
+      setLocalPendingState(false);
+      localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
+    }
+  };
+
   // Ensure hover state is only applied when appropriate
   const shouldShowHover = isHovered && !isSelected && !isProcessing;
 
@@ -128,6 +167,26 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
       data-hovered={shouldShowHover ? "true" : "false"}
     >
       <CardContent className="p-4 text-center relative">
+        {/* Prioritize button - battle context */}
+        <button
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          onClick={handlePrioritizeClick}
+          className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-opacity duration-200 ${
+            isPendingRefinement ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          }`}
+          title="Prioritize for refinement battle"
+          type="button"
+        >
+          <Star
+            className={`w-16 h-16 transition-all ${
+              isPendingRefinement ? 'text-yellow-400 fill-yellow-400' : 'text-gray-500 hover:text-yellow-500'
+            }`}
+          />
+        </button>
+
         {/* Info Button - exact copy from manual mode */}
         <div className="absolute top-1 right-1 z-30 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
           <Dialog open={isOpen} onOpenChange={setIsOpen}>

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -220,8 +220,8 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
         </div>
       )}
 
-      {/* Prioritize button - only for ranked context and when not dragging */}
-      {!isDragging && context === 'ranked' && (
+      {/* Prioritize button - ranked and available contexts */}
+      {!isDragging && (context === 'ranked' || context === 'available') && (
         <button
           onPointerDown={(e) => {
             // Prevent the drag listeners from capturing this interaction so
@@ -230,14 +230,14 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
             e.preventDefault();
           }}
           onClick={handlePrioritizeClick}
-          className={`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-30 p-2 rounded-full transition-opacity duration-200 ${
+          className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-opacity duration-200 ${
             isPendingRefinement ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
           }`}
           title="Prioritize for refinement battle"
           type="button"
         >
           <Star
-            className={`w-8 h-8 transition-all ${
+            className={`w-16 h-16 transition-all ${
               isPendingRefinement ? 'text-yellow-400 fill-yellow-400' : 'text-gray-500 hover:text-yellow-500'
             }`}
           />


### PR DESCRIPTION
## Summary
- reposition star button to the right side of ranking cards
- double the size of the star icon
- show star button on battle cards and available pokemon cards

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*
- `npm test` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68476ae3d4488333b55588fb3432ce49