### PR TITLE
Show battle star on available Pokemon cards

### DIFF
--- a/src/components/battle/BattleCardContainer.tsx
+++ b/src/components/battle/BattleCardContainer.tsx
@@ -52,10 +52,24 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
     ? refinementQueue.some(b => b.primaryPokemonId === pokemon.id) || localPendingState
     : localPendingState;
 
+  const hadRefinementBattlesRef = useRef(false);
+
   useEffect(() => {
-    if (contextAvailable && hasRefinementBattles === false && localPendingState) {
+    if (hasRefinementBattles) {
+      hadRefinementBattlesRef.current = true;
+    }
+  }, [hasRefinementBattles]);
+
+  useEffect(() => {
+    if (
+      contextAvailable &&
+      hasRefinementBattles === false &&
+      localPendingState &&
+      hadRefinementBattlesRef.current
+    ) {
       setLocalPendingState(false);
       localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
+      hadRefinementBattlesRef.current = false;
     }
   }, [contextAvailable, hasRefinementBattles, localPendingState, pokemon.id]);
 

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -122,12 +122,27 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
     }
   };
 
+  const hadRefinementBattlesRef = React.useRef(false);
+
+  // Track if there have ever been refinement battles
+  React.useEffect(() => {
+    if (hasRefinementBattles) {
+      hadRefinementBattlesRef.current = true;
+    }
+  }, [hasRefinementBattles]);
+
   // Clean up localStorage when Pokemon is actually processed in a battle
   React.useEffect(() => {
-    if (contextAvailable && hasRefinementBattles === false && localPendingState) {
+    if (
+      contextAvailable &&
+      hasRefinementBattles === false &&
+      localPendingState &&
+      hadRefinementBattlesRef.current
+    ) {
       console.log(`🌟 [CLEANUP_TRACE] Clearing pending state for ${pokemon.name} - battles processed`);
       setLocalPendingState(false);
       localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
+      hadRefinementBattlesRef.current = false;
     }
   }, [contextAvailable, hasRefinementBattles, localPendingState, pokemon.id, pokemon.name]);
 
@@ -231,7 +246,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
           }}
           onClick={handlePrioritizeClick}
           className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-opacity duration-200 ${
-            isPendingRefinement ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+            isPendingRefinement ? 'opacity-100' : 'opacity-80 hover:opacity-100'
           }`}
           title="Prioritize for refinement battle"
           type="button"

--- a/src/components/battle/TCGBattleCard.tsx
+++ b/src/components/battle/TCGBattleCard.tsx
@@ -58,10 +58,24 @@ const TCGBattleCard: React.FC<TCGBattleCardProps> = memo(({
     ? refinementQueue.some(b => b.primaryPokemonId === pokemon.id) || localPendingState
     : localPendingState;
 
+  const hadRefinementBattlesRef = React.useRef(false);
+
   React.useEffect(() => {
-    if (contextAvailable && hasRefinementBattles === false && localPendingState) {
+    if (hasRefinementBattles) {
+      hadRefinementBattlesRef.current = true;
+    }
+  }, [hasRefinementBattles]);
+
+  React.useEffect(() => {
+    if (
+      contextAvailable &&
+      hasRefinementBattles === false &&
+      localPendingState &&
+      hadRefinementBattlesRef.current
+    ) {
       setLocalPendingState(false);
       localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
+      hadRefinementBattlesRef.current = false;
     }
   }, [contextAvailable, hasRefinementBattles, localPendingState, pokemon.id]);
 


### PR DESCRIPTION
## Summary
- adjust star visibility on DraggablePokemonMilestoneCard so it's visible without hovering
- keep star highlighted for available and battle cards when no refinement battles have been queued yet

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684796086ce483338f343c862d1a115c