### PR TITLE
Add queue logging and cleanup notices

### DIFF
--- a/src/components/battle/BattleCardContainer.tsx
+++ b/src/components/battle/BattleCardContainer.tsx
@@ -69,6 +69,7 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
       localPendingState &&
       hadRefinementBattlesRef.current
     ) {
+      console.log(`🌟 [CLEANUP_TRACE] Cleared pending state for ${pokemon.name} (#${pokemon.id}) - battles processed`);
       setLocalPendingState(false);
       localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
       hadRefinementBattlesRef.current = false;
@@ -155,8 +156,10 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
           const rand = Math.floor(Math.random() * copy.length);
           opponents.push(copy.splice(rand, 1)[0].id);
         }
+        console.log(`🌟 [BATTLE_CARD] Opponents chosen for ${pokemon.name} (#${pokemon.id}):`, opponents);
         try {
-          queueBattlesForReorder(pokemon.id, opponents, -1);
+          const newLength = queueBattlesForReorder(pokemon.id, opponents, -1);
+          console.log(`🌟 [BATTLE_CARD_QUEUE] New queue length after queuing for ${pokemon.name} (#${pokemon.id}): ${newLength}`);
         } catch (error) {
           console.error('Failed to queue refinement battles from battle card', error);
         }

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -94,12 +94,12 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
             opponents.push(opponent.id);
           }
 
-          console.log(`🌟 [STAR_CLICK_DETAILED] Random opponents for ${pokemon.name}:`, opponents);
+          console.log(`🌟 [STAR_CLICK_DETAILED] (${context}) Opponents chosen for ${pokemon.name} (#${pokemon.id}):`, opponents);
 
           if (opponents.length > 0) {
             try {
-              queueBattlesForReorder(pokemon.id, opponents, currentIndex);
-              console.log(`🌟 [STAR_CLICK_DETAILED] ✅ queueBattlesForReorder call completed successfully`);
+              const newLength = queueBattlesForReorder(pokemon.id, opponents, currentIndex);
+              console.log(`🌟 [STAR_QUEUE_${context.toUpperCase()}] New queue length after queuing for ${pokemon.name} (#${pokemon.id}): ${newLength}`);
             } catch (error) {
               console.error(`🌟 [STAR_CLICK_DETAILED] ❌ Error calling queueBattlesForReorder:`, error);
             }
@@ -141,7 +141,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       localPendingState &&
       hadRefinementBattlesRef.current
     ) {
-      console.log(`🌟 [CLEANUP_TRACE] Clearing pending state for ${pokemon.name} - battles processed`);
+      console.log(`🌟 [CLEANUP_TRACE] (${context}) Cleared pending state for ${pokemon.name} (#${pokemon.id}) - battles processed`);
       setLocalPendingState(false);
       localStorage.removeItem(`pokemon-pending-${pokemon.id}`);
       hadRefinementBattlesRef.current = false;

--- a/src/hooks/battle/useRefinementQueue.ts
+++ b/src/hooks/battle/useRefinementQueue.ts
@@ -57,7 +57,7 @@ export const useRefinementQueue = () => {
     console.log(`🔄 [ADD_VALIDATION_TRACE] ===== ADD VALIDATION BATTLE END =====`);
   }, []);
 
-  const queueBattlesForReorder = useCallback((primaryId: number, neighbors: number[], newPosition: number) => {
+  const queueBattlesForReorder = useCallback((primaryId: number, neighbors: number[], newPosition: number): number => {
     console.log(`🔄 [QUEUE_BATTLES_MEGA_TRACE] ===== QUEUEING VALIDATION BATTLES START =====`);
     console.log(`🔄 [QUEUE_BATTLES_MEGA_TRACE] Input parameters:`, {
       primaryId,
@@ -71,6 +71,8 @@ export const useRefinementQueue = () => {
       return;
     }
     
+    let resultingLength = currentQueueRef.current.length;
+
     setRefinementQueue(prev => {
       console.log(`🔄 [QUEUE_BATTLES_MEGA_TRACE] Current queue before operation:`, {
         length: prev.length,
@@ -136,6 +138,7 @@ export const useRefinementQueue = () => {
       }
 
       currentQueueRef.current = shuffledQueue;
+      resultingLength = shuffledQueue.length;
       
       console.log(`🔄 [QUEUE_BATTLES_MEGA_TRACE] ✅ FINAL RESULT:`, {
         oldQueueLength: prev.length,
@@ -147,6 +150,8 @@ export const useRefinementQueue = () => {
 
       return shuffledQueue;
     });
+
+    return resultingLength;
   }, [isDuplicateBattleGlobally]);
 
   const getNextRefinementBattle = useCallback((): RefinementBattle | null => {


### PR DESCRIPTION
## Summary
- log selected opponents and queue length when generating opponents for ranked and battle modes
- return queue length from `queueBattlesForReorder`
- log ID on cleanup when pending state is cleared

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a4acb9408333b6b57f86dbdbc3f7