### PR TITLE
Fix BattleStarterEvents conflicts

### DIFF
--- a/src/hooks/battle/useBattleStarterEvents.ts
+++ b/src/hooks/battle/useBattleStarterEvents.ts
@@ -1,4 +1,3 @@
-
 import { useEffect, useRef } from "react";
 import { Pokemon } from "@/services/pokemon";
 import { useCloudPendingBattles } from "./useCloudPendingBattles";
@@ -8,48 +7,83 @@ export const useBattleStarterEvents = (
   currentBattle: Pokemon[],
   initialBattleStartedRef: React.MutableRefObject<boolean>,
   autoTriggerDisabledRef: React.MutableRefObject<boolean>,
-  startNewBattleCallbackRef: React.MutableRefObject<((battleType: any) => any[]) | null>,
+  startNewBattleCallbackRef: React.MutableRefObject<
+    ((battleType: any) => any[]) | null
+  >,
   initializationTimerRef: React.MutableRefObject<NodeJS.Timeout | null>,
   initializationCompleteRef: React.MutableRefObject<boolean>,
   stableSetCurrentBattle: (battle: Pokemon[]) => void,
-  stableSetSelectedPokemon: (pokemon: number[]) => void
+  stableSetSelectedPokemon: (pokemon: number[]) => void,
 ) => {
   const { getAllPendingIds, isHydrated } = useCloudPendingBattles();
   const pendingCheckRef = useRef(false);
 
   // CRITICAL FIX: Check for pending Pokemon when battle mode initializes
   useEffect(() => {
-    if (!isHydrated || pendingCheckRef.current) return;
+    console.log(
+      `🔍 [BATTLE_STARTER_EVENTS] Init effect fired. isHydrated=${isHydrated}, pendingChecked=${pendingCheckRef.current}, filteredLength=${filteredPokemon.length}`,
+    );
+    if (filteredPokemon.length === 0) {
+      console.log(
+        `🔍 [BATTLE_STARTER_EVENTS] Exiting init check early - no filtered Pokémon yet`,
+      );
+      return;
+    }
+    if (!isHydrated || pendingCheckRef.current) {
+      console.log(
+        `🔍 [BATTLE_STARTER_EVENTS] Skipping init check - isHydrated=${isHydrated}, alreadyChecked=${pendingCheckRef.current}`,
+      );
+      return;
+    }
 
     const checkPendingOnInit = () => {
       const pendingIds = getAllPendingIds();
-      console.log(`🎯 [BATTLE_STARTER_EVENTS] Checking pending Pokemon on init: ${pendingIds}`);
-      
+      console.log(
+        `🎯 [BATTLE_STARTER_EVENTS] Checking pending Pokemon on init: ${pendingIds}`,
+      );
+
       if (pendingIds.length > 0) {
-        console.log(`🎯 [BATTLE_STARTER_EVENTS] Found ${pendingIds.length} pending Pokemon, starting battle`);
-        
+        console.log(
+          `🎯 [BATTLE_STARTER_EVENTS] Found ${pendingIds.length} pending Pokemon, starting battle`,
+        );
+
         // Set flag to prevent duplicate checks
         pendingCheckRef.current = true;
-        
+
         // Small delay to ensure all components are ready
         setTimeout(() => {
           if (startNewBattleCallbackRef.current && currentBattle.length === 0) {
-            console.log(`🎯 [BATTLE_STARTER_EVENTS] Triggering battle for pending Pokemon`);
+            console.log(
+              `🎯 [BATTLE_STARTER_EVENTS] Triggering battle for pending Pokemon`,
+            );
             const result = startNewBattleCallbackRef.current("pairs");
-            console.log(`🎯 [BATTLE_STARTER_EVENTS] Battle result:`, result?.map(p => p.name));
+            console.log(
+              `🎯 [BATTLE_STARTER_EVENTS] Battle result:`,
+              result?.map((p) => p.name),
+            );
           } else {
-            console.log(`🎯 [BATTLE_STARTER_EVENTS] Battle callback not ready or battle already exists`);
+            console.log(
+              `🎯 [BATTLE_STARTER_EVENTS] Battle callback not ready or battle already exists`,
+            );
           }
         }, 100);
       } else {
-        console.log(`🎯 [BATTLE_STARTER_EVENTS] No pending Pokemon found on init`);
+        console.log(
+          `🎯 [BATTLE_STARTER_EVENTS] No pending Pokemon found on init`,
+        );
         pendingCheckRef.current = true;
       }
     };
 
     // Run the check immediately if hydrated
     checkPendingOnInit();
-  }, [isHydrated, getAllPendingIds, currentBattle.length, startNewBattleCallbackRef]);
+  }, [
+    isHydrated,
+    getAllPendingIds,
+    currentBattle.length,
+    startNewBattleCallbackRef,
+    filteredPokemon.length,
+  ]);
 
   // CRITICAL FIX: Auto-trigger first battle when no battle exists and we have Pokemon
   useEffect(() => {
@@ -61,14 +95,21 @@ export const useBattleStarterEvents = (
       startNewBattleCallbackRef.current &&
       isHydrated
     ) {
-      console.log(`🔥 [BATTLE_STARTER_EVENTS] Auto-triggering first battle with ${filteredPokemon.length} Pokemon`);
-      
+      console.log(
+        `🔥 [BATTLE_STARTER_EVENTS] Auto-triggering first battle with ${filteredPokemon.length} Pokemon`,
+      );
+
       // Small delay to ensure all hooks are ready
       const triggerTimer = setTimeout(() => {
         if (startNewBattleCallbackRef.current) {
-          console.log(`🔥 [BATTLE_STARTER_EVENTS] Executing auto-trigger for first battle`);
+          console.log(
+            `🔥 [BATTLE_STARTER_EVENTS] Executing auto-trigger for first battle`,
+          );
           const result = startNewBattleCallbackRef.current("pairs");
-          console.log(`🔥 [BATTLE_STARTER_EVENTS] Auto-trigger result:`, result?.map(p => p.name));
+          console.log(
+            `🔥 [BATTLE_STARTER_EVENTS] Auto-trigger result:`,
+            result?.map((p) => p.name),
+          );
           initialBattleStartedRef.current = true;
         }
       }, 200);
@@ -81,28 +122,53 @@ export const useBattleStarterEvents = (
     initialBattleStartedRef,
     autoTriggerDisabledRef,
     startNewBattleCallbackRef,
-    isHydrated
+    isHydrated,
   ]);
 
   // CRITICAL FIX: Listen for mode switch events and check for pending battles
   useEffect(() => {
+    console.log(
+      `🔍 [BATTLE_STARTER_EVENTS] Mode switch listener effect fired. isHydrated=${isHydrated}, filteredLength=${filteredPokemon.length}`,
+    );
+    if (filteredPokemon.length === 0) {
+      console.log(
+        `🔍 [BATTLE_STARTER_EVENTS] Exiting mode switch listener - no filtered Pokémon yet`,
+      );
+      return;
+    }
+    if (!isHydrated) {
+      console.log(
+        `🔍 [BATTLE_STARTER_EVENTS] Mode switch listener waiting for hydration`,
+      );
+      return;
+    }
     const handleModeSwitch = (event: CustomEvent) => {
-      console.log(`🎯 [BATTLE_STARTER_EVENTS] Mode switch detected:`, event.detail);
-      
-      if (event.detail?.mode === 'battle' && isHydrated) {
+      console.log(
+        `🎯 [BATTLE_STARTER_EVENTS] Mode switch detected:`,
+        event.detail,
+      );
+
+      if (event.detail?.mode === "battle" && isHydrated) {
         // Reset pending check flag when switching to battle mode
         pendingCheckRef.current = false;
-        
+
         // Check for pending Pokemon after mode switch
         setTimeout(() => {
           const pendingIds = getAllPendingIds();
-          console.log(`🎯 [BATTLE_STARTER_EVENTS] Post-switch pending check: ${pendingIds}`);
-          
+          console.log(
+            `🎯 [BATTLE_STARTER_EVENTS] Post-switch pending check: ${pendingIds}`,
+          );
+
           if (pendingIds.length > 0 && currentBattle.length === 0) {
-            console.log(`🎯 [BATTLE_STARTER_EVENTS] Triggering battle after mode switch`);
+            console.log(
+              `🎯 [BATTLE_STARTER_EVENTS] Triggering battle after mode switch`,
+            );
             if (startNewBattleCallbackRef.current) {
               const result = startNewBattleCallbackRef.current("pairs");
-              console.log(`🎯 [BATTLE_STARTER_EVENTS] Post-switch battle result:`, result?.map(p => p.name));
+              console.log(
+                `🎯 [BATTLE_STARTER_EVENTS] Post-switch battle result:`,
+                result?.map((p) => p.name),
+              );
             }
           }
         }, 300);
@@ -110,12 +176,21 @@ export const useBattleStarterEvents = (
     };
 
     // Listen for mode switch events
-    document.addEventListener('mode-switch', handleModeSwitch as EventListener);
-    
+    document.addEventListener("mode-switch", handleModeSwitch as EventListener);
+
     return () => {
-      document.removeEventListener('mode-switch', handleModeSwitch as EventListener);
+      document.removeEventListener(
+        "mode-switch",
+        handleModeSwitch as EventListener,
+      );
     };
-  }, [getAllPendingIds, currentBattle.length, startNewBattleCallbackRef, isHydrated]);
+  }, [
+    getAllPendingIds,
+    currentBattle.length,
+    startNewBattleCallbackRef,
+    isHydrated,
+    filteredPokemon.length,
+  ]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- format `useBattleStarterEvents` file to remove merge conflict markers
- ensure early-exit logic and debug logging are retained

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684844659eec8333a1f0bcd2c0990672