### PR TITLE
Switch BattleModeContainer to refactored battle hook

### DIFF
--- a/src/components/battle/BattleModeContainer.tsx
+++ b/src/components/battle/BattleModeContainer.tsx
@@ -4,7 +4,8 @@ import BattleContentHeader from "./BattleContentHeader";
 import BattleContentRenderer from "./BattleContentRenderer";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType, SingleBattle } from "@/hooks/battle/types";
-import { useBattleStateCore } from "@/hooks/battle/useBattleStateCore";
+// Switch to the refactored battle state hook that uses the coordination system
+import { useBattleStateCoreRefactored } from "@/hooks/battle/useBattleStateCoreRefactored";
 import { useTrueSkillStore } from "@/stores/trueskillStore";
 
 interface BattleModeContainerProps {
@@ -28,7 +29,13 @@ const BattleModeContainer: React.FC<BattleModeContainerProps> = ({
   const { totalBattles } = useTrueSkillStore();
 
   // CRITICAL FIX: Use the battle state from the core hook directly
-  const battleState = useBattleStateCore(allPokemon, initialBattleType, selectedGeneration);
+  // The refactored hook internally uses the coordination system and
+  // triggers battle starter events for pending Pokémon
+  const battleState = useBattleStateCoreRefactored(
+    allPokemon,
+    initialBattleType,
+    selectedGeneration
+  );
 
   // CRITICAL FIX: Always use TrueSkill store value for battles completed
   useEffect(() => {

--- a/src/hooks/battle/useBattleStateEffects.ts
+++ b/src/hooks/battle/useBattleStateEffects.ts
@@ -99,14 +99,7 @@ export const useBattleStateEffects = (
       // Start initial battle immediately without delay
       if (startNewBattle) {
         console.log(`🚀 [BATTLE_INIT_ULTRA_DEBUG] Calling startNewBattle`);
-        const config = {
-          allPokemon,
-          currentRankings: getCurrentRankings(),
-          battleType,
-          selectedGeneration,
-          freezeList: frozenPokemon
-        };
-        const initialBattle = startNewBattle(config);
+        const initialBattle = startNewBattle(battleType);
         if (initialBattle && initialBattle.length > 0) {
           console.log(`✅ [BATTLE_INIT_ULTRA_DEBUG] Initial battle created:`, initialBattle.map(p => p.name).join(' vs '));
           setCurrentBattle(initialBattle);


### PR DESCRIPTION
## Summary
- use the refactored battle state hook in `BattleModeContainer`
- adjust `useBattleStateEffects` to match the new `startNewBattle` signature

## Testing
- `npm run lint` *(fails: 323 errors, 71 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684867bda8c88333964ca6f6ac09a191