### PR TITLE
Fix pending battle hydration status

### DIFF
--- a/src/hooks/battle/useBattleStarterEvents.ts
+++ b/src/hooks/battle/useBattleStarterEvents.ts
@@ -16,6 +16,11 @@ export const useBattleStarterEvents = (
   stableSetSelectedPokemon: (pokemon: number[]) => void
 ) => {
   const { getAllPendingIds, isHydrated } = useCloudPendingBattles();
+  useEffect(() => {
+    console.log(
+      `🎯 [BATTLE_STARTER_EVENTS] Hydration status from pending hook: ${isHydrated}`
+    );
+  }, [isHydrated]);
   const pendingCheckRef = useRef(false);
 
   // CRITICAL FIX: Check for pending Pokemon when battle mode initializes

--- a/src/hooks/battle/useCloudPendingBattles.ts
+++ b/src/hooks/battle/useCloudPendingBattles.ts
@@ -1,5 +1,5 @@
 
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useTrueSkillStore } from '@/stores/trueskillStore';
 
 export const useCloudPendingBattles = () => {
@@ -70,6 +70,16 @@ export const useCloudPendingBattles = () => {
 
   const hasPendingPokemon = getAllPendingBattles().length > 0;
 
+  // If we somehow loaded pending battles but hydration flag is false, fix it
+  useEffect(() => {
+    if (getAllPendingBattles().length > 0 && !isHydrated) {
+      console.warn(
+        '[CLOUD_PENDING_HOOK] Pending battles present but isHydrated is false. Forcing hydration.'
+      );
+      useTrueSkillStore.setState({ isHydrated: true });
+    }
+  }, [isHydrated, getAllPendingBattles]);
+
   // Debug render
   console.log(`🔥🔥🔥 [CLOUD_PENDING_HOOK] Hook render:`, {
     hasPendingPokemon,
@@ -78,6 +88,10 @@ export const useCloudPendingBattles = () => {
     isHydrated,
     timestamp: new Date().toISOString()
   });
+
+  useEffect(() => {
+    console.log(`🔥🔥🔥 [CLOUD_PENDING_HOOK] Hydration status changed: ${isHydrated}`);
+  }, [isHydrated]);
 
   return {
     pendingPokemon: getAllPendingBattles(),

--- a/src/stores/trueskillStore.ts
+++ b/src/stores/trueskillStore.ts
@@ -265,12 +265,18 @@ export const useTrueSkillStore = create<TrueSkillStore>()(
           
           const result = await response.json();
           if (result.success && result.ratings) {
-            console.log(`[TRUESKILL_STORE] Loaded ${Object.keys(result.ratings).length} ratings, ${result.totalBattles || 0} total battles, ${(result.pendingBattles || []).length} pending battles from cloud`);
-            set({ 
+            console.log(
+              `[TRUESKILL_STORE] Loaded ${Object.keys(result.ratings).length} ratings, ${
+                result.totalBattles || 0} total battles, ${
+                (result.pendingBattles || []).length} pending battles from cloud`
+            );
+            set({
               ratings: result.ratings,
               totalBattles: result.totalBattles || 0,
-              pendingBattles: result.pendingBattles || []
+              pendingBattles: result.pendingBattles || [],
+              isHydrated: true
             });
+            console.log('[TRUESKILL_STORE] Hydration flag set after cloud load');
           }
         } catch (error) {
           console.error('[TRUESKILL_STORE] Load from cloud failed:', error);
@@ -341,6 +347,8 @@ export const useTrueSkillStore = create<TrueSkillStore>()(
           }
           
           console.log(`[TRUESKILL_SMART_SYNC] Smart sync completed successfully`);
+          set({ isHydrated: true });
+          console.log('[TRUESKILL_STORE] Hydration flag set after smart sync');
           
         } catch (error) {
           console.error('[TRUESKILL_SMART_SYNC] Smart sync failed:', error);


### PR DESCRIPTION
## Summary
- mark store as hydrated when loading from cloud and after smart sync
- recover from hydration mismatch in `useCloudPendingBattles`
- log hydration changes for debugging
- log hydration state in `useBattleStarterEvents`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6848aa495d4c8333a7af99efdbe57ffa