### PR TITLE
Add debugging logs for battle selection and processing

### DIFF
--- a/src/hooks/battle/useBattleSelection.ts
+++ b/src/hooks/battle/useBattleSelection.ts
@@ -1,5 +1,5 @@
 
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType } from "./types";
 
@@ -12,6 +12,11 @@ export const useBattleSelection = (
   processBattleResultWithRefinement: any,
   handleBattleCompleted: any
 ) => {
+  console.log(
+    "🔄 [BATTLE_SELECTION_DEBUG] Hook initialized with setter:",
+    setSelectedPokemon
+  );
+
   const handlePokemonSelect = useCallback((pokemonId: number) => {
     console.log(`🎯 [POKEMON_SELECT_ULTRA_DEBUG] Pokemon ${pokemonId} selected. Current selections: ${JSON.stringify(selectedPokemon)}`);
     
@@ -33,6 +38,13 @@ export const useBattleSelection = (
       processBattleResultWithRefinement(newSelection, currentBattle, battleType, selectedGeneration);
     }
   }, [selectedPokemon, setSelectedPokemon, battleType, currentBattle, selectedGeneration, processBattleResultWithRefinement, handleBattleCompleted]);
+
+  useEffect(() => {
+    console.log(
+      "🔄 [BATTLE_SELECTION_DEBUG] selectedPokemon updated:",
+      selectedPokemon
+    );
+  }, [selectedPokemon]);
 
   return { handlePokemonSelect };
 };

--- a/src/hooks/battle/useBattleStateProcessing.ts
+++ b/src/hooks/battle/useBattleStateProcessing.ts
@@ -1,5 +1,5 @@
 
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType } from "./types";
 
@@ -16,6 +16,19 @@ export const useBattleStateProcessing = (
   startNewBattleWrapper: () => void
 ) => {
   const processingRef = useRef(false);
+
+  console.log(
+    "🔄 [BATTLE_PROCESSING_DEBUG] Hook initialized with setters:",
+    setIsBattleTransitioning,
+    setIsAnyProcessing
+  );
+
+  useEffect(() => {
+    console.log(
+      "🔄 [BATTLE_PROCESSING_DEBUG] selectedPokemon changed:",
+      selectedPokemon
+    );
+  }, [selectedPokemon]);
 
   const handleTripletSelectionComplete = useCallback(async () => {
     const expectedCount = battleType === "pairs" ? 1 : 2;


### PR DESCRIPTION
## Summary
- trace selected Pokémon updates inside `useBattleSelection`
- add initialization and state change logs in `useBattleStateProcessing`

## Testing
- `npm install`
- `npm run lint` *(fails: 394 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6848ab1a0828833391c386cbed233e22