### PR TITLE
Send mode switch events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,13 @@ function AppContent() {
     };
   }, []);
 
+  useEffect(() => {
+    const evt = new CustomEvent('mode-switch', {
+      detail: { mode, timestamp: new Date().toISOString() }
+    });
+    document.dispatchEvent(evt);
+  }, [mode]);
+
   const handleModeChange = (newMode: "rank" | "battle") => {
     console.log('🚀🚀🚀 APP_CONTENT_FIXED: Mode changing from', mode, 'to', newMode);
     setMode(newMode);

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -179,12 +179,18 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
             e.preventDefault();
             console.log(`🌥️ [CARD_DEBUG] onPointerDown called for ${pokemon.name}`);
           }}
+          onPointerUp={(e) => {
+            e.stopPropagation();
+          }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
+          }}
           onClick={handlePrioritizeClick}
           className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-all duration-300 ${
-            isPendingRefinement 
-              ? 'opacity-100' 
-              : isHovered 
-                ? 'opacity-100' 
+            isPendingRefinement
+              ? 'opacity-100'
+              : isHovered
+                ? 'opacity-100'
                 : 'opacity-0 pointer-events-none'
           }`}
           title={isPendingRefinement ? "Remove from refinement queue" : "Prioritize for refinement battle"}

--- a/src/components/battle/TCGBattleCard.tsx
+++ b/src/components/battle/TCGBattleCard.tsx
@@ -206,12 +206,18 @@ const TCGBattleCard: React.FC<TCGBattleCardProps> = memo(({
             e.stopPropagation();
             e.preventDefault();
           }}
+          onPointerUp={(e) => {
+            e.stopPropagation();
+          }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
+          }}
           onClick={handlePrioritizeClick}
           className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-all duration-300 ${
-            isPendingRefinement 
-              ? 'opacity-100' 
-              : isHovered && !isProcessing 
-                ? 'opacity-100' 
+            isPendingRefinement
+              ? 'opacity-100'
+              : isHovered && !isProcessing
+                ? 'opacity-100'
                 : 'opacity-0 pointer-events-none'
           }`}
           title={isPendingRefinement ? "Remove from refinement queue" : "Prioritize for refinement battle"}


### PR DESCRIPTION
## Summary
- ensure `AppContent` dispatches `mode-switch` whenever mode changes
- stop propagation on star buttons so card clicks don't trigger when selecting priority

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6849080333d483338e1c2c8e15506ca5