### PR TITLE
Add ModeContext provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,16 @@
 
-import React, { useState, useEffect, useRef } from "react";
-import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
+import React, { useEffect, useRef } from "react";
+
 import BattleMode from "@/components/battle/BattleModeCore";
 import AppHeader from "@/components/layout/AppHeader";
-import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { Toaster } from "@/components/ui/toaster"
 import PokemonRankerWithProvider from "@/components/pokemon/PokemonRankerWithProvider";
 import { AuthWrapper } from "@/components/auth/AuthWrapper";
 import { RefinementQueueProvider } from "@/components/battle/RefinementQueueProvider";
+import { ModeProvider, useMode } from "@/contexts/ModeContext";
 
 function AppContent() {
-  const [mode, setMode] = useLocalStorage<"rank" | "battle">("pokemon-ranker-mode", "rank");
+  const { mode, setMode } = useMode();
   const renderCount = useRef(0);
   const mountTime = useRef(new Date().toISOString());
   const stableInstance = useRef('app-content-main-stable-FIXED');
@@ -97,12 +97,6 @@ function AppContent() {
     };
   }, []);
 
-  useEffect(() => {
-    const evt = new CustomEvent('mode-switch', {
-      detail: { mode, timestamp: new Date().toISOString() }
-    });
-    document.dispatchEvent(evt);
-  }, [mode]);
 
   const handleModeChange = (newMode: "rank" | "battle") => {
     console.log('🚀🚀🚀 APP_CONTENT_FIXED: Mode changing from', mode, 'to', newMode);
@@ -193,10 +187,12 @@ function App() {
   }, []);
   
   console.log('🚀🚀🚀 ROOT_APP_FIXED: About to render fixed structure');
-  
+
   return (
     <AuthWrapper>
-      <AppContent />
+      <ModeProvider>
+        <AppContent />
+      </ModeProvider>
     </AuthWrapper>
   );
 }

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -1,14 +1,15 @@
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useRef, useEffect } from "react";
 import { Settings } from 'lucide-react';
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import BattleModeCore from "./battle/BattleModeCore";
 import PokemonRankerProvider from "./pokemon/PokemonRankerProvider";
 import PokemonRankerWithProvider from "./pokemon/PokemonRankerWithProvider";
+import { useMode } from "@/contexts/ModeContext";
 
 const AppContent: React.FC = () => {
-  const [mode, setMode] = useState<"rank" | "battle">("rank");
+  const { mode, setMode } = useMode();
   
   const renderCountRef = useRef(0);
   renderCountRef.current += 1;
@@ -22,21 +23,6 @@ const AppContent: React.FC = () => {
   const handleModeChange = (newMode: "rank" | "battle") => {
     console.log(`🔥🔥🔥 [MODE_SWITCH_${Date.now()}_${Math.random().toString(36).substr(2, 9)}] Mode changing from ${mode} to ${newMode}`);
     setMode(newMode);
-    
-    // CRITICAL FIX: Dispatch mode switch event for battle starter
-    const event = new CustomEvent('mode-switch', { 
-      detail: { 
-        mode: newMode, 
-        previousMode: mode,
-        timestamp: new Date().toISOString()
-      } 
-    });
-    
-    // Delay the dispatch to ensure state has updated
-    setTimeout(() => {
-      console.log(`🔥🔥🔥 [MODE_SWITCH_${Date.now()}_${Math.random().toString(36).substr(2, 9)}] Dispatching event for mode: ${newMode}`);
-      document.dispatchEvent(event);
-    }, 50);
   };
 
   return (

--- a/src/contexts/ModeContext.tsx
+++ b/src/contexts/ModeContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+interface ModeContextType {
+  mode: 'rank' | 'battle';
+  setMode: (mode: 'rank' | 'battle') => void;
+}
+
+const ModeContext = createContext<ModeContextType | undefined>(undefined);
+
+export const ModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [mode, setMode] = useLocalStorage<'rank' | 'battle'>(
+    'pokemon-ranker-mode',
+    'rank'
+  );
+
+  const value = React.useMemo(() => ({ mode, setMode }), [mode, setMode]);
+
+  return <ModeContext.Provider value={value}>{children}</ModeContext.Provider>;
+};
+
+export const useMode = () => {
+  const context = useContext(ModeContext);
+  if (!context) {
+    throw new Error('useMode must be used within a ModeProvider');
+  }
+  return context;
+};

--- a/src/hooks/battle/useBattleStarterEvents.ts
+++ b/src/hooks/battle/useBattleStarterEvents.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { useMode } from "@/contexts/ModeContext";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType } from "./types";
 import { useTrueSkillStore } from "@/stores/trueskillStore";
@@ -20,6 +21,7 @@ export const useBattleStarterEvents = (
   
   const { initiatePendingBattle, setInitiatePendingBattle } = useTrueSkillStore();
   const { getAllPendingIds, removePendingPokemon } = useCloudPendingBattles();
+  const { mode } = useMode();
 
   // MASTER_BATTLE_START: The single authoritative battle coordinator
   useEffect(() => {
@@ -169,32 +171,21 @@ export const useBattleStarterEvents = (
     initiatePendingBattle
   ]);
 
-  // Mode switch event listener
+  // React to mode changes directly
   useEffect(() => {
-    const handleModeSwitch = (event: any) => {
-      const { mode, timestamp } = event.detail;
-      console.log(`🔄 [MODE_SWITCH_HANDLER] Mode switched to: ${mode} at ${timestamp}`);
-      
-      if (mode === 'battle') {
-        console.log(`🚦 [MODE_COORDINATION] Entering battle mode, checking for pending battles`);
-        
-        const pendingIds = getAllPendingIds();
-        if (pendingIds && Array.isArray(pendingIds) && pendingIds.length > 0) {
-          console.log(`🚦 [MODE_COORDINATION] Found pending battles: ${pendingIds}`);
-          console.log(`🚦 [MODE_COORDINATION] Setting initiatePendingBattle flag to: true`);
-          setInitiatePendingBattle(true);
-        } else {
-          console.log(`🚦 [MODE_COORDINATION] No pending battles found`);
-        }
-      }
-    };
+    if (mode !== 'battle') return;
 
-    document.addEventListener('mode-switch', handleModeSwitch);
-    
-    return () => {
-      document.removeEventListener('mode-switch', handleModeSwitch);
-    };
-  }, [getAllPendingIds, setInitiatePendingBattle]);
+    console.log(`🚦 [MODE_COORDINATION] Mode is 'battle', checking for pending battles`);
+
+    const pendingIds = getAllPendingIds();
+    if (pendingIds && Array.isArray(pendingIds) && pendingIds.length > 0) {
+      console.log(`🚦 [MODE_COORDINATION] Found pending battles: ${pendingIds}`);
+      console.log(`🚦 [MODE_COORDINATION] Setting initiatePendingBattle flag to: true`);
+      setInitiatePendingBattle(true);
+    } else {
+      console.log(`🚦 [MODE_COORDINATION] No pending battles found`);
+    }
+  }, [mode, getAllPendingIds, setInitiatePendingBattle]);
 
   // Reset refs when Pokemon data changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- create `ModeContext` for globally tracking rank/battle mode
- update `App` and `AppContent` to use the new context
- remove mode-switch event dispatch logic and timeout
- react to mode changes directly in `useBattleStarterEvents`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849aa82447c833395887841fcc9eb1c