### PR TITLE
Fix star button not interfering with drag

### DIFF
--- a/src/components/battle/BattleCardContainer.tsx
+++ b/src/components/battle/BattleCardContainer.tsx
@@ -88,10 +88,17 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
     
     // Simple check for info button clicks - match manual mode approach
     const target = e.target as HTMLElement;
-    const isInfoButtonClick = target.closest('[data-info-button="true"]') || 
+    const isInfoButtonClick = target.closest('[data-info-button="true"]') ||
         target.closest('[data-radix-dialog-content]') ||
         target.closest('[data-radix-dialog-overlay]') ||
         target.closest('[role="dialog"]');
+
+    // Skip selection if clicking the star prioritize button
+    if (target.closest('[data-priority-button="true"]')) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
     
     if (isInfoButtonClick) {
       console.log(`ℹ️ [INFO_BUTTON_DEBUG] BattleCardContainer: Info dialog interaction for ${displayName}, preventing card selection`);
@@ -201,6 +208,7 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
       <CardContent className="p-4 text-center relative">
         {/* Prioritize button - only visible on card hover */}
         <button
+          data-priority-button="true"
           onPointerDown={(e) => {
             e.stopPropagation();
             e.preventDefault();

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -92,6 +92,21 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
     isDragging,
   } = sortableResult;
 
+  // Wrap sortable listeners to ignore events originating from the priority button
+  const wrappedListeners = React.useMemo(() => {
+    const entries = Object.entries(listeners).map(([key, handler]) => {
+      if (typeof handler !== 'function') return [key, handler];
+      return [key, (event: any) => {
+        const target = event.target as HTMLElement;
+        if (target?.closest('[data-priority-button="true"]')) {
+          return;
+        }
+        return (handler as Function)(event);
+      }];
+    });
+    return Object.fromEntries(entries) as typeof listeners;
+  }, [listeners]);
+
   const style = {
     transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0) scaleX(${transform.scaleX || 1}) scaleY(${transform.scaleY || 1})` : 'translate3d(0, 0, 0)',
     transition: transition || undefined,
@@ -149,7 +164,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       {...(isDraggable && !isOpen ? attributes : {})}
-      {...(isDraggable && !isOpen ? listeners : {})}
+      {...(isDraggable && !isOpen ? wrappedListeners : {})}
     >
       {/* Enhanced drag overlay for better visual feedback */}
       {isDragging && (
@@ -174,6 +189,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       {/* Prioritize button - only visible on card hover */}
       {!isDragging && (context === 'ranked' || context === 'available') && (
         <button
+          data-priority-button="true"
           onPointerDown={(e) => {
             e.stopPropagation();
             e.preventDefault();

--- a/src/components/battle/TCGBattleCard.tsx
+++ b/src/components/battle/TCGBattleCard.tsx
@@ -92,10 +92,17 @@ const TCGBattleCard: React.FC<TCGBattleCardProps> = memo(({
     
     // Check for info button clicks - match manual mode approach
     const target = e.target as HTMLElement;
-    const isInfoButtonClick = target.closest('[data-info-button="true"]') || 
+    const isInfoButtonClick = target.closest('[data-info-button="true"]') ||
         target.closest('[data-radix-dialog-content]') ||
         target.closest('[data-radix-dialog-overlay]') ||
         target.closest('[role="dialog"]');
+
+    // Skip selection if clicking the star prioritize button
+    if (target.closest('[data-priority-button="true"]')) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
     
     if (isInfoButtonClick) {
       console.log(`ℹ️ [INFO_BUTTON_DEBUG] TCGBattleCard: Info dialog interaction for ${displayName}, preventing card selection`);
@@ -202,6 +209,7 @@ const TCGBattleCard: React.FC<TCGBattleCardProps> = memo(({
       <CardContent className="p-4 text-center relative">
         {/* Prioritize button - only visible on card hover */}
         <button
+          data-priority-button="true"
           onPointerDown={(e) => {
             e.stopPropagation();
             e.preventDefault();


### PR DESCRIPTION
## Summary
- skip selection in `BattleCardContainer` and `TCGBattleCard` when clicking the star button
- mark the star button with `data-priority-button="true"`
- wrap dnd-kit listeners in `DraggablePokemonMilestoneCard` to ignore events from the star button

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849aca33ccc8333aca0e11a9fd844e3