### PR TITLE
Send mode switch events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,27 @@
-
 import React, { useState, useEffect, useRef } from "react";
-import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Route,
+  Routes,
+  Navigate,
+} from "react-router-dom";
 import BattleMode from "@/components/battle/BattleModeCore";
 import AppHeader from "@/components/layout/AppHeader";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
-import { Toaster } from "@/components/ui/toaster"
+import { Toaster } from "@/components/ui/toaster";
 import PokemonRankerWithProvider from "@/components/pokemon/PokemonRankerWithProvider";
 import { AuthWrapper } from "@/components/auth/AuthWrapper";
 import { RefinementQueueProvider } from "@/components/battle/RefinementQueueProvider";
+import { useTrueSkillStore } from "@/stores/trueskillStore";
 
 function AppContent() {
-  const [mode, setMode] = useLocalStorage<"rank" | "battle">("pokemon-ranker-mode", "rank");
+  const [mode, setMode] = useLocalStorage<"rank" | "battle">(
+    "pokemon-ranker-mode",
+    "rank",
+  );
   const renderCount = useRef(0);
   const mountTime = useRef(new Date().toISOString());
-  const stableInstance = useRef('app-content-main-stable-FIXED');
+  const stableInstance = useRef("app-content-main-stable-FIXED");
   const unmountDetectedRef = useRef(false);
   const intervalRefs = useRef<NodeJS.Timeout[]>([]);
   const lastLogTime = useRef(0);
@@ -21,89 +29,145 @@ function AppContent() {
   renderCount.current += 1;
 
   // CRITICAL: Ensure we're logging with the correct _FIXED identifier
-  console.log('🚀🚀🚀 APP_CONTENT_FIXED: ===== FIXED APP CONTENT RENDER =====');
-  console.log('🚀🚀🚀 APP_CONTENT_FIXED: Instance ID:', stableInstance.current);
-  console.log('🚀🚀🚀 APP_CONTENT_FIXED: Render count:', renderCount.current);
-  console.log('🚀🚀🚀 APP_CONTENT_FIXED: Mount time:', mountTime.current);
-  console.log('🚀🚀🚀 APP_CONTENT_FIXED: Mode:', mode);
+  console.log("🚀🚀🚀 APP_CONTENT_FIXED: ===== FIXED APP CONTENT RENDER =====");
+  console.log("🚀🚀🚀 APP_CONTENT_FIXED: Instance ID:", stableInstance.current);
+  console.log("🚀🚀🚀 APP_CONTENT_FIXED: Render count:", renderCount.current);
+  console.log("🚀🚀🚀 APP_CONTENT_FIXED: Mount time:", mountTime.current);
+  console.log("🚀🚀🚀 APP_CONTENT_FIXED: Mode:", mode);
 
   useEffect(() => {
-    console.log('🚀🚀🚀 APP_CONTENT_FIXED: ===== FIXED APP CONTENT MOUNTED =====');
-    console.log('🚀🚀🚀 APP_CONTENT_FIXED: Component mounted at:', new Date().toISOString());
-    console.log('🚀🚀🚀 APP_CONTENT_FIXED: Instance ID on mount:', stableInstance.current);
-    
+    console.log(
+      "🚀🚀🚀 APP_CONTENT_FIXED: ===== FIXED APP CONTENT MOUNTED =====",
+    );
+    console.log(
+      "🚀🚀🚀 APP_CONTENT_FIXED: Component mounted at:",
+      new Date().toISOString(),
+    );
+    console.log(
+      "🚀🚀🚀 APP_CONTENT_FIXED: Instance ID on mount:",
+      stableInstance.current,
+    );
+
     // Store globally for debugging
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       (window as any).appContentInstance = stableInstance.current;
       (window as any).appContentMounted = true;
     }
-    
+
     // Add monitoring with throttling to reduce log spam
     const monitoringInterval = setInterval(() => {
       if (unmountDetectedRef.current) {
-        console.log('🚀🚀🚀 APP_CONTENT_FIXED: ⚠️ UNMOUNT FLAG DETECTED ⚠️');
+        console.log("🚀🚀🚀 APP_CONTENT_FIXED: ⚠️ UNMOUNT FLAG DETECTED ⚠️");
         return;
       }
-      
+
       const now = Date.now();
       // Only log every 30 seconds to reduce spam
       if (now - lastLogTime.current > 30000) {
-        console.log('🚀🚀🚀 APP_CONTENT_FIXED: 🔍 MONITORING CHECK - Still mounted:', {
-          instance: stableInstance.current,
-          time: new Date().toLocaleTimeString(),
-          renderCount: renderCount.current,
-          mode: mode,
-          timestamp: new Date().toISOString()
-        });
+        console.log(
+          "🚀🚀🚀 APP_CONTENT_FIXED: 🔍 MONITORING CHECK - Still mounted:",
+          {
+            instance: stableInstance.current,
+            time: new Date().toLocaleTimeString(),
+            renderCount: renderCount.current,
+            mode: mode,
+            timestamp: new Date().toISOString(),
+          },
+        );
         lastLogTime.current = now;
       }
     }, 6000);
-    
+
     intervalRefs.current.push(monitoringInterval);
-    
+
     // Listen for page navigation/reload
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: ===== PAGE UNLOAD DETECTED =====');
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: 🚨 PAGE IS RELOADING/NAVIGATING AWAY 🚨');
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: This explains why app-content would disappear');
+      console.log("🚀🚀🚀 APP_CONTENT_FIXED: ===== PAGE UNLOAD DETECTED =====");
+      console.log(
+        "🚀🚀🚀 APP_CONTENT_FIXED: 🚨 PAGE IS RELOADING/NAVIGATING AWAY 🚨",
+      );
+      console.log(
+        "🚀🚀🚀 APP_CONTENT_FIXED: This explains why app-content would disappear",
+      );
     };
-    
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
     return () => {
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: ===== FIXED APP CONTENT UNMOUNT DETECTED =====');
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: 🚨🚨🚨 COMPONENT IS UNMOUNTING 🚨🚨🚨');
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: Unmounting at:', new Date().toISOString());
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: Instance that unmounted:', stableInstance.current);
-      console.log('🚀🚀🚀 APP_CONTENT_FIXED: Mode at unmount:', mode);
-      
+      console.log(
+        "🚀🚀🚀 APP_CONTENT_FIXED: ===== FIXED APP CONTENT UNMOUNT DETECTED =====",
+      );
+      console.log(
+        "🚀🚀🚀 APP_CONTENT_FIXED: 🚨🚨🚨 COMPONENT IS UNMOUNTING 🚨🚨🚨",
+      );
+      console.log(
+        "🚀🚀🚀 APP_CONTENT_FIXED: Unmounting at:",
+        new Date().toISOString(),
+      );
+      console.log(
+        "🚀🚀🚀 APP_CONTENT_FIXED: Instance that unmounted:",
+        stableInstance.current,
+      );
+      console.log("🚀🚀🚀 APP_CONTENT_FIXED: Mode at unmount:", mode);
+
       unmountDetectedRef.current = true;
-      
-      if (typeof window !== 'undefined') {
+
+      if (typeof window !== "undefined") {
         (window as any).appContentUnmountDetected = {
           instance: stableInstance.current,
           mode,
           renderCount: renderCount.current,
-          unmountTime: new Date().toISOString()
+          unmountTime: new Date().toISOString(),
         };
         (window as any).appContentMounted = false;
       }
-      
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      
+
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+
       // Clear all intervals
-      intervalRefs.current.forEach(interval => clearInterval(interval));
+      intervalRefs.current.forEach((interval) => clearInterval(interval));
       intervalRefs.current = [];
     };
   }, []);
 
+  const { waitForHydration } = useTrueSkillStore();
+
+  useEffect(() => {
+    let cancelled = false;
+    const timeout = setTimeout(async () => {
+      if (mode === "battle") {
+        try {
+          await waitForHydration();
+        } catch (err) {
+          console.error("[mode-switch] hydration wait failed", err);
+        }
+      }
+      if (!cancelled) {
+        const evt = new CustomEvent("mode-switch", {
+          detail: { mode, timestamp: new Date().toISOString() },
+        });
+        document.dispatchEvent(evt);
+      }
+    }, 0);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [mode, waitForHydration]);
+
   const handleModeChange = (newMode: "rank" | "battle") => {
-    console.log('🚀🚀🚀 APP_CONTENT_FIXED: Mode changing from', mode, 'to', newMode);
+    console.log(
+      "🚀🚀🚀 APP_CONTENT_FIXED: Mode changing from",
+      mode,
+      "to",
+      newMode,
+    );
     setMode(newMode);
   };
 
   const renderContent = () => {
-    console.log('🚀🚀🚀 APP_CONTENT_FIXED: Rendering content for mode:', mode);
+    console.log("🚀🚀🚀 APP_CONTENT_FIXED: Rendering content for mode:", mode);
     if (mode === "battle") {
       return <BattleMode />;
     } else {
@@ -116,11 +180,9 @@ function AppContent() {
     <RefinementQueueProvider>
       <div className="flex flex-col h-screen">
         <AppHeader mode={mode} onModeChange={handleModeChange} />
-        
+
         <main className="flex-grow bg-gray-100 py-6 px-4">
-          <div className="container max-w-7xl mx-auto">
-            {renderContent()}
-          </div>
+          <div className="container max-w-7xl mx-auto">{renderContent()}</div>
         </main>
         <Toaster />
       </div>
@@ -131,62 +193,82 @@ function AppContent() {
 function App() {
   const renderCount = useRef(0);
   const mountTime = useRef(new Date().toISOString());
-  const stableRootInstance = useRef('app-root-main-stable-FIXED');
+  const stableRootInstance = useRef("app-root-main-stable-FIXED");
   const unmountDetectedRef = useRef(false);
   const intervalRefs = useRef<NodeJS.Timeout[]>([]);
   const lastLogTime = useRef(0);
-  
+
   renderCount.current += 1;
 
   // CRITICAL: Ensure we're logging with the correct _FIXED identifier
-  console.log('🚀🚀🚀 ROOT_APP_FIXED: ===== FIXED ROOT APP RENDER =====');
-  console.log('🚀🚀🚀 ROOT_APP_FIXED: Instance ID:', stableRootInstance.current);
-  console.log('🚀🚀🚀 ROOT_APP_FIXED: Render count:', renderCount.current);
-  console.log('🚀🚀🚀 ROOT_APP_FIXED: Mount time:', mountTime.current);
-  
+  console.log("🚀🚀🚀 ROOT_APP_FIXED: ===== FIXED ROOT APP RENDER =====");
+  console.log(
+    "🚀🚀🚀 ROOT_APP_FIXED: Instance ID:",
+    stableRootInstance.current,
+  );
+  console.log("🚀🚀🚀 ROOT_APP_FIXED: Render count:", renderCount.current);
+  console.log("🚀🚀🚀 ROOT_APP_FIXED: Mount time:", mountTime.current);
+
   useEffect(() => {
-    console.log('🚀🚀🚀 ROOT_APP_FIXED: ===== ROOT MOUNT EFFECT =====');
-    console.log('🚀🚀🚀 ROOT_APP_FIXED: Root component mounted at:', new Date().toISOString());
-    console.log('🚀🚀🚀 ROOT_APP_FIXED: Stable root instance on mount:', stableRootInstance.current);
-    
+    console.log("🚀🚀🚀 ROOT_APP_FIXED: ===== ROOT MOUNT EFFECT =====");
+    console.log(
+      "🚀🚀🚀 ROOT_APP_FIXED: Root component mounted at:",
+      new Date().toISOString(),
+    );
+    console.log(
+      "🚀🚀🚀 ROOT_APP_FIXED: Stable root instance on mount:",
+      stableRootInstance.current,
+    );
+
     // Add monitoring with throttling
     const monitoringInterval = setInterval(() => {
       if (unmountDetectedRef.current) {
-        console.log('🚀🚀🚀 ROOT_APP_FIXED: ⚠️ ROOT UNMOUNT FLAG DETECTED ⚠️');
+        console.log("🚀🚀🚀 ROOT_APP_FIXED: ⚠️ ROOT UNMOUNT FLAG DETECTED ⚠️");
         return;
       }
-      
+
       const now = Date.now();
       // Only log every 40 seconds to reduce spam
       if (now - lastLogTime.current > 40000) {
-        console.log('🚀🚀🚀 ROOT_APP_FIXED: 🔍 ROOT MONITORING CHECK - Still mounted:', {
-          instance: stableRootInstance.current,
-          time: new Date().toLocaleTimeString(),
-          renderCount: renderCount.current,
-          timestamp: new Date().toISOString()
-        });
+        console.log(
+          "🚀🚀🚀 ROOT_APP_FIXED: 🔍 ROOT MONITORING CHECK - Still mounted:",
+          {
+            instance: stableRootInstance.current,
+            time: new Date().toLocaleTimeString(),
+            renderCount: renderCount.current,
+            timestamp: new Date().toISOString(),
+          },
+        );
         lastLogTime.current = now;
       }
     }, 8000);
-    
+
     intervalRefs.current.push(monitoringInterval);
-    
+
     return () => {
-      console.log('🚀🚀🚀 ROOT_APP_FIXED: ===== ROOT UNMOUNT DETECTED =====');
-      console.log('🚀🚀🚀 ROOT_APP_FIXED: 🚨🚨🚨 ROOT COMPONENT UNMOUNTING 🚨🚨🚨');
-      console.log('🚀🚀🚀 ROOT_APP_FIXED: Root unmounting at:', new Date().toISOString());
-      console.log('🚀🚀🚀 ROOT_APP_FIXED: Root instance that unmounted:', stableRootInstance.current);
-      
+      console.log("🚀🚀🚀 ROOT_APP_FIXED: ===== ROOT UNMOUNT DETECTED =====");
+      console.log(
+        "🚀🚀🚀 ROOT_APP_FIXED: 🚨🚨🚨 ROOT COMPONENT UNMOUNTING 🚨🚨🚨",
+      );
+      console.log(
+        "🚀🚀🚀 ROOT_APP_FIXED: Root unmounting at:",
+        new Date().toISOString(),
+      );
+      console.log(
+        "🚀🚀🚀 ROOT_APP_FIXED: Root instance that unmounted:",
+        stableRootInstance.current,
+      );
+
       unmountDetectedRef.current = true;
-      
+
       // Clear all intervals
-      intervalRefs.current.forEach(interval => clearInterval(interval));
+      intervalRefs.current.forEach((interval) => clearInterval(interval));
       intervalRefs.current = [];
     };
   }, []);
-  
-  console.log('🚀🚀🚀 ROOT_APP_FIXED: About to render fixed structure');
-  
+
+  console.log("🚀🚀🚀 ROOT_APP_FIXED: About to render fixed structure");
+
   return (
     <AuthWrapper>
       <AppContent />

--- a/src/components/battle/BattleCardContainer.tsx
+++ b/src/components/battle/BattleCardContainer.tsx
@@ -1,7 +1,13 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Pokemon } from "@/services/pokemon";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import PokemonModalContent from "@/components/pokemon/PokemonModalContent";
 import { usePokemonFlavorText } from "@/hooks/pokemon/usePokemonFlavorText";
 import { usePokemonTCGCard } from "@/hooks/pokemon/usePokemonTCGCard";
@@ -29,7 +35,7 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
   onSelect,
   isProcessing,
   imageUrl,
-  displayName
+  displayName,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -37,16 +43,18 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
   const [isHovered, setIsHovered] = useState(false);
 
   // CRITICAL FIX: Use cloud pending battles instead of local state
-  const { isPokemonPending, addPendingPokemon, removePendingPokemon } = useCloudPendingBattles();
+  const { isPokemonPending, addPendingPokemon, removePendingPokemon } =
+    useCloudPendingBattles();
   const isPendingRefinement = isPokemonPending(pokemon.id);
 
-  const { refinementQueue, hasRefinementBattles, queueBattlesForReorder } = useSharedRefinementQueue();
+  const { refinementQueue, hasRefinementBattles, queueBattlesForReorder } =
+    useSharedRefinementQueue();
   const { allPokemon } = usePokemonContext();
 
   const contextAvailable = Boolean(
     refinementQueue &&
-    Array.isArray(refinementQueue) &&
-    typeof hasRefinementBattles === 'boolean'
+      Array.isArray(refinementQueue) &&
+      typeof hasRefinementBattles === "boolean",
   );
 
   const hadRefinementBattlesRef = useRef(false);
@@ -64,18 +72,37 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
       isPendingRefinement &&
       hadRefinementBattlesRef.current
     ) {
-      console.log(`🌟 [CLEANUP_TRACE] Cleared pending state for ${pokemon.name} (#${pokemon.id}) - battles processed`);
+      console.log(
+        `🌟 [CLEANUP_TRACE] Cleared pending state for ${pokemon.name} (#${pokemon.id}) - battles processed`,
+      );
       removePendingPokemon(pokemon.id);
       hadRefinementBattlesRef.current = false;
     }
-  }, [contextAvailable, hasRefinementBattles, isPendingRefinement, pokemon.id, removePendingPokemon]);
+  }, [
+    contextAvailable,
+    hasRefinementBattles,
+    isPendingRefinement,
+    pokemon.id,
+    removePendingPokemon,
+  ]);
 
   // Hooks for modal content - match manual mode approach
-  const { flavorText, isLoadingFlavor } = usePokemonFlavorText(pokemon.id, isOpen);
-  const { tcgCard, secondTcgCard, isLoading: isLoadingTCG, error: tcgError, hasTcgCard } = usePokemonTCGCard(pokemon.name, isOpen);
+  const { flavorText, isLoadingFlavor } = usePokemonFlavorText(
+    pokemon.id,
+    isOpen,
+  );
+  const {
+    tcgCard,
+    secondTcgCard,
+    isLoading: isLoadingTCG,
+    error: tcgError,
+    hasTcgCard,
+  } = usePokemonTCGCard(pokemon.name, isOpen);
 
   useEffect(() => {
-    console.log(`🔘 [INFO_BUTTON_DEBUG] BattleCardContainer ${displayName}: Component mounted/updated`);
+    console.log(
+      `🔘 [INFO_BUTTON_DEBUG] BattleCardContainer ${displayName}: Component mounted/updated`,
+    );
     return () => {
       if (clickTimeoutRef.current) {
         clearTimeout(clickTimeoutRef.current);
@@ -83,54 +110,71 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
     };
   }, [displayName]);
 
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    console.log(`🖱️ [INFO_BUTTON_DEBUG] BattleCardContainer ${displayName}: Card clicked`);
-    
-    // Simple check for info button clicks - match manual mode approach
-    const target = e.target as HTMLElement;
-    const isInfoButtonClick = target.closest('[data-info-button="true"]') || 
-        target.closest('[data-radix-dialog-content]') ||
-        target.closest('[data-radix-dialog-overlay]') ||
-        target.closest('[role="dialog"]');
-    
-    if (isInfoButtonClick) {
-      console.log(`ℹ️ [INFO_BUTTON_DEBUG] BattleCardContainer: Info dialog interaction for ${displayName}, preventing card selection`);
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      console.log(
+        `🖱️ [INFO_BUTTON_DEBUG] BattleCardContainer ${displayName}: Card clicked`,
+      );
 
-    const now = Date.now();
-    
-    // Prevent rapid double-clicks
-    if (now - lastClickTimeRef.current < 300) {
-      console.log(`🚫 BattleCardContainer: Ignoring rapid click on ${displayName}`);
-      return;
-    }
-    
-    lastClickTimeRef.current = now;
-    
-    console.log(`🖱️ BattleCardContainer: Click on ${displayName} (${pokemon.id}) - processing: ${isProcessing}`);
-    
-    if (clickTimeoutRef.current) {
-      clearTimeout(clickTimeoutRef.current);
-    }
-    
-    clickTimeoutRef.current = setTimeout(() => {
-      onSelect(pokemon.id);
-      clickTimeoutRef.current = null;
-    }, 50);
-  }, [pokemon.id, displayName, onSelect, isProcessing]);
+      // Simple check for info button clicks - match manual mode approach
+      const target = e.target as HTMLElement;
+      const isInfoButtonClick =
+        target.closest('[data-info-button="true"]') ||
+        target.closest("[data-radix-dialog-content]") ||
+        target.closest("[data-radix-dialog-overlay]") ||
+        target.closest('[role="dialog"]');
+      const isStarClick = target.closest('[data-priority-button="true"]');
+
+      if (isInfoButtonClick || isStarClick) {
+        console.log(
+          `ℹ️ [INFO_BUTTON_DEBUG] BattleCardContainer: Info dialog interaction for ${displayName}, preventing card selection`,
+        );
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+
+      const now = Date.now();
+
+      // Prevent rapid double-clicks
+      if (now - lastClickTimeRef.current < 300) {
+        console.log(
+          `🚫 BattleCardContainer: Ignoring rapid click on ${displayName}`,
+        );
+        return;
+      }
+
+      lastClickTimeRef.current = now;
+
+      console.log(
+        `🖱️ BattleCardContainer: Click on ${displayName} (${pokemon.id}) - processing: ${isProcessing}`,
+      );
+
+      if (clickTimeoutRef.current) {
+        clearTimeout(clickTimeoutRef.current);
+      }
+
+      clickTimeoutRef.current = setTimeout(() => {
+        onSelect(pokemon.id);
+        clickTimeoutRef.current = null;
+      }, 50);
+    },
+    [pokemon.id, displayName, onSelect, isProcessing],
+  );
 
   const handleMouseEnter = useCallback(() => {
-    console.log(`🔘 [HOVER_DEBUG] BattleCardContainer ${displayName}: Mouse enter - isProcessing: ${isProcessing}`);
+    console.log(
+      `🔘 [HOVER_DEBUG] BattleCardContainer ${displayName}: Mouse enter - isProcessing: ${isProcessing}`,
+    );
     if (!isProcessing) {
       setIsHovered(true);
     }
   }, [isProcessing, displayName]);
 
   const handleMouseLeave = useCallback(() => {
-    console.log(`🔘 [HOVER_DEBUG] BattleCardContainer ${displayName}: Mouse leave`);
+    console.log(
+      `🔘 [HOVER_DEBUG] BattleCardContainer ${displayName}: Mouse leave`,
+    );
     setIsHovered(false);
   }, [displayName]);
 
@@ -138,32 +182,46 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
     e.stopPropagation();
     e.preventDefault();
 
-    console.log(`⭐ [STAR_TOGGLE_FIXED] Star clicked for ${pokemon.name} - current pending: ${isPendingRefinement}`);
+    console.log(
+      `⭐ [STAR_TOGGLE_FIXED] Star clicked for ${pokemon.name} - current pending: ${isPendingRefinement}`,
+    );
 
     if (!isPendingRefinement) {
       // CRITICAL FIX: Use cloud pending system
-      console.log(`⭐ [STAR_TOGGLE_FIXED] Adding ${pokemon.name} to CLOUD pending state`);
+      console.log(
+        `⭐ [STAR_TOGGLE_FIXED] Adding ${pokemon.name} to CLOUD pending state`,
+      );
       addPendingPokemon(pokemon.id);
 
       if (contextAvailable && allPokemon.length > 1) {
-        const pool = allPokemon.filter(p => p.id !== pokemon.id);
+        const pool = allPokemon.filter((p) => p.id !== pokemon.id);
         const opponents: number[] = [];
         const copy = [...pool];
         while (opponents.length < 3 && copy.length > 0) {
           const rand = Math.floor(Math.random() * copy.length);
           opponents.push(copy.splice(rand, 1)[0].id);
         }
-        console.log(`🌟 [BATTLE_CARD] Opponents chosen for ${pokemon.name} (#${pokemon.id}):`, opponents);
+        console.log(
+          `🌟 [BATTLE_CARD] Opponents chosen for ${pokemon.name} (#${pokemon.id}):`,
+          opponents,
+        );
         try {
           const newLength = queueBattlesForReorder(pokemon.id, opponents, -1);
-          console.log(`🌟 [BATTLE_CARD_QUEUE] New queue length after queuing for ${pokemon.name} (#${pokemon.id}): ${newLength}`);
+          console.log(
+            `🌟 [BATTLE_CARD_QUEUE] New queue length after queuing for ${pokemon.name} (#${pokemon.id}): ${newLength}`,
+          );
         } catch (error) {
-          console.error('Failed to queue refinement battles from battle card', error);
+          console.error(
+            "Failed to queue refinement battles from battle card",
+            error,
+          );
         }
       }
     } else {
       // CRITICAL FIX: Use cloud pending system
-      console.log(`⭐ [STAR_TOGGLE_FIXED] Removing ${pokemon.name} from CLOUD pending state`);
+      console.log(
+        `⭐ [STAR_TOGGLE_FIXED] Removing ${pokemon.name} from CLOUD pending state`,
+      );
       removePendingPokemon(pokemon.id);
     }
   };
@@ -173,9 +231,9 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
 
   const cardClasses = `
     relative cursor-pointer transition-all duration-200 transform group
-    ${isSelected ? 'ring-4 ring-blue-500 bg-blue-50 scale-105 shadow-xl' : 'hover:scale-105 hover:shadow-lg'}
-    ${isProcessing ? 'pointer-events-none' : ''}
-    ${shouldShowHover ? 'ring-2 ring-blue-300 ring-opacity-50' : ''}
+    ${isSelected ? "ring-4 ring-blue-500 bg-blue-50 scale-105 shadow-xl" : "hover:scale-105 hover:shadow-lg"}
+    ${isProcessing ? "pointer-events-none" : ""}
+    ${shouldShowHover ? "ring-2 ring-blue-300 ring-opacity-50" : ""}
   `.trim();
 
   const handleDialogClick = (e: React.MouseEvent) => {
@@ -188,7 +246,7 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
   const showFallbackInfo = !isLoadingTCG && !hasTcgCard;
 
   return (
-    <Card 
+    <Card
       className={cardClasses}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
@@ -201,35 +259,52 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
       <CardContent className="p-4 text-center relative">
         {/* Prioritize button - only visible on card hover */}
         <button
+          data-priority-button="true"
           onPointerDown={(e) => {
             e.stopPropagation();
             e.preventDefault();
           }}
+          onPointerUp={(e) => {
+            e.stopPropagation();
+          }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
+          }}
           onClick={handlePrioritizeClick}
           className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-all duration-300 ${
-            isPendingRefinement 
-              ? 'opacity-100' 
-              : isHovered && !isProcessing 
-                ? 'opacity-100' 
-                : 'opacity-0 pointer-events-none'
+            isPendingRefinement
+              ? "opacity-100"
+              : isHovered && !isProcessing
+                ? "opacity-100"
+                : "opacity-0 pointer-events-none"
           }`}
-          title={isPendingRefinement ? "Remove from refinement queue" : "Prioritize for refinement battle"}
+          title={
+            isPendingRefinement
+              ? "Remove from refinement queue"
+              : "Prioritize for refinement battle"
+          }
           type="button"
         >
           <Star
             className={`w-16 h-16 transition-all duration-300 ${
-              isPendingRefinement ? 'text-yellow-400 fill-yellow-400' : 'text-gray-500 hover:text-yellow-500'
+              isPendingRefinement
+                ? "text-yellow-400 fill-yellow-400"
+                : "text-gray-500 hover:text-yellow-500"
             }`}
           />
         </button>
 
         {/* Info Button - only visible on card hover */}
-        <div className={`absolute top-1 right-1 z-30 transition-all duration-300 ${
-          isHovered && !isProcessing ? 'opacity-100' : 'opacity-0 pointer-events-none'
-        }`}>
+        <div
+          className={`absolute top-1 right-1 z-30 transition-all duration-300 ${
+            isHovered && !isProcessing
+              ? "opacity-100"
+              : "opacity-0 pointer-events-none"
+          }`}
+        >
           <Dialog open={isOpen} onOpenChange={setIsOpen}>
             <DialogTrigger asChild>
-              <button 
+              <button
                 className="w-5 h-5 rounded-full bg-white/80 hover:bg-white border border-gray-300 text-gray-600 hover:text-gray-800 flex items-center justify-center text-xs font-medium shadow-sm transition-all duration-200 backdrop-blur-sm cursor-pointer"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -242,13 +317,13 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
                   e.stopPropagation();
                 }}
                 type="button"
-                style={{ pointerEvents: 'auto' }}
+                style={{ pointerEvents: "auto" }}
               >
                 i
               </button>
             </DialogTrigger>
-            
-            <DialogContent 
+
+            <DialogContent
               className="max-w-4xl max-h-[90vh] overflow-y-auto pointer-events-auto"
               onClick={handleDialogClick}
               data-radix-dialog-content="true"
@@ -274,7 +349,7 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
         </div>
 
         {/* Interactive elements */}
-        <BattleCardInteractions 
+        <BattleCardInteractions
           isHovered={shouldShowHover}
           isSelected={isSelected}
           isProcessing={isProcessing}
@@ -282,14 +357,14 @@ const BattleCardContainer: React.FC<BattleCardContainerProps> = ({
 
         <div className="relative">
           {/* Pokemon Image */}
-          <BattleCardImage 
+          <BattleCardImage
             imageUrl={imageUrl}
             displayName={displayName}
             pokemonId={pokemon.id}
           />
 
           {/* Pokemon Info */}
-          <BattleCardInfo 
+          <BattleCardInfo
             displayName={displayName}
             pokemonId={pokemon.id}
             types={pokemon.types}

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -1,10 +1,15 @@
-
 import React from "react";
-import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Pokemon, RankedPokemon } from "@/services/pokemon";
 import { getPokemonBackgroundColor } from "./utils/PokemonColorUtils";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import PokemonModalContent from "@/components/pokemon/PokemonModalContent";
 import { usePokemonFlavorText } from "@/hooks/pokemon/usePokemonFlavorText";
 import { usePokemonTCGCard } from "@/hooks/pokemon/usePokemonTCGCard";
@@ -19,51 +24,70 @@ interface DraggablePokemonMilestoneCardProps {
   showRank?: boolean;
   isDraggable?: boolean;
   isAvailable?: boolean;
-  context?: 'available' | 'ranked';
+  context?: "available" | "ranked";
   allRankedPokemon?: (Pokemon | RankedPokemon)[];
 }
 
-const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps> = ({ 
-  pokemon, 
-  index, 
+const DraggablePokemonMilestoneCard: React.FC<
+  DraggablePokemonMilestoneCardProps
+> = ({
+  pokemon,
+  index,
   isPending = false,
   showRank = true,
   isDraggable = true,
   isAvailable = false,
-  context = 'ranked',
-  allRankedPokemon = []
+  context = "ranked",
+  allRankedPokemon = [],
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [isHovered, setIsHovered] = React.useState(false);
-  
+
   // Use the cloud-based pending state hook
-  const { isPokemonPending, addPendingPokemon, removePendingPokemon, isHydrated } = useCloudPendingBattles();
-  
-  console.log(`🌥️ [CARD_DEBUG] ${pokemon.name} card render - Pending: ${isPokemonPending(pokemon.id)}, Hydrated: ${isHydrated}`);
-  
+  const {
+    isPokemonPending,
+    addPendingPokemon,
+    removePendingPokemon,
+    isHydrated,
+  } = useCloudPendingBattles();
+
+  console.log(
+    `🌥️ [CARD_DEBUG] ${pokemon.name} card render - Pending: ${isPokemonPending(pokemon.id)}, Hydrated: ${isHydrated}`,
+  );
+
   const handlePrioritizeClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-    
+
     console.log(`🌥️ [CARD_DEBUG] ===== STAR CLICKED FOR ${pokemon.name} =====`);
-    console.log(`🌥️ [CARD_DEBUG] Pokemon ID: ${pokemon.id}, Context: ${context}`);
-    console.log(`🌥️ [CARD_DEBUG] Current pending state: ${isPokemonPending(pokemon.id)}`);
+    console.log(
+      `🌥️ [CARD_DEBUG] Pokemon ID: ${pokemon.id}, Context: ${context}`,
+    );
+    console.log(
+      `🌥️ [CARD_DEBUG] Current pending state: ${isPokemonPending(pokemon.id)}`,
+    );
     console.log(`🌥️ [CARD_DEBUG] Timestamp: ${new Date().toISOString()}`);
-    
+
     if (!isHydrated) {
-      console.warn(`🌥️ [CARD_DEBUG] ⚠️ Store not hydrated yet, skipping action`);
+      console.warn(
+        `🌥️ [CARD_DEBUG] ⚠️ Store not hydrated yet, skipping action`,
+      );
       return;
     }
-    
+
     const currentlyPending = isPokemonPending(pokemon.id);
-    
+
     if (!currentlyPending) {
       // Add to cloud-based pending state
-      console.log(`⭐ [MILESTONE_STAR_TOGGLE] Adding ${pokemon.name} to pending state`);
+      console.log(
+        `⭐ [MILESTONE_STAR_TOGGLE] Adding ${pokemon.name} to pending state`,
+      );
       addPendingPokemon(pokemon.id);
     } else {
       // Remove from cloud-based pending state
-      console.log(`⭐ [MILESTONE_STAR_TOGGLE] Removing ${pokemon.name} from pending state`);
+      console.log(
+        `⭐ [MILESTONE_STAR_TOGGLE] Removing ${pokemon.name} from pending state`,
+      );
       removePendingPokemon(pokemon.id);
     }
   };
@@ -71,16 +95,21 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   // Check if this Pokemon has pending state
   const isPendingRefinement = isPokemonPending(pokemon.id);
 
-  const sortableResult = useSortable({ 
-    id: isDraggable ? (isAvailable ? `available-${pokemon.id}` : pokemon.id) : `static-${pokemon.id}`,
+  const sortableResult = useSortable({
+    id: isDraggable
+      ? isAvailable
+        ? `available-${pokemon.id}`
+        : pokemon.id
+      : `static-${pokemon.id}`,
     disabled: !isDraggable || isOpen,
     data: {
-      type: context === 'available' ? 'available-pokemon' : 'ranked-pokemon',
+      type: context === "available" ? "available-pokemon" : "ranked-pokemon",
       pokemon: pokemon,
       source: context,
       index,
-      isRanked: context === 'available' && 'isRanked' in pokemon && pokemon.isRanked
-    }
+      isRanked:
+        context === "available" && "isRanked" in pokemon && pokemon.isRanked,
+    },
   });
 
   const {
@@ -93,23 +122,34 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   } = sortableResult;
 
   const style = {
-    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0) scaleX(${transform.scaleX || 1}) scaleY(${transform.scaleY || 1})` : 'translate3d(0, 0, 0)',
+    transform: transform
+      ? `translate3d(${transform.x}px, ${transform.y}px, 0) scaleX(${transform.scaleX || 1}) scaleY(${transform.scaleY || 1})`
+      : "translate3d(0, 0, 0)",
     transition: transition || undefined,
-    minHeight: '140px',
-    minWidth: '140px',
-    zIndex: isDragging ? 1000 : 'auto',
-    cursor: isDraggable && !isOpen ? 'grab' : 'default',
-    willChange: isDragging ? 'transform' : 'auto',
-    backfaceVisibility: 'hidden' as const,
+    minHeight: "140px",
+    minWidth: "140px",
+    zIndex: isDragging ? 1000 : "auto",
+    cursor: isDraggable && !isOpen ? "grab" : "default",
+    willChange: isDragging ? "transform" : "auto",
+    backfaceVisibility: "hidden" as const,
     perspective: 1000,
-    transformStyle: 'preserve-3d' as const
+    transformStyle: "preserve-3d" as const,
   };
 
   const backgroundColorClass = getPokemonBackgroundColor(pokemon);
 
   // Hooks for modal content
-  const { flavorText, isLoadingFlavor } = usePokemonFlavorText(pokemon.id, isOpen);
-  const { tcgCard, secondTcgCard, isLoading: isLoadingTCG, error: tcgError, hasTcgCard } = usePokemonTCGCard(pokemon.name, isOpen);
+  const { flavorText, isLoadingFlavor } = usePokemonFlavorText(
+    pokemon.id,
+    isOpen,
+  );
+  const {
+    tcgCard,
+    secondTcgCard,
+    isLoading: isLoadingTCG,
+    error: tcgError,
+    hasTcgCard,
+  } = usePokemonTCGCard(pokemon.name, isOpen);
 
   // Determine what content to show
   const showLoading = isLoadingTCG;
@@ -131,21 +171,27 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   };
 
   // Format Pokemon ID with leading zeros
-  const formattedId = pokemon.id.toString().padStart(pokemon.id >= 10000 ? 5 : 3, '0');
+  const formattedId = pokemon.id
+    .toString()
+    .padStart(pokemon.id >= 10000 ? 5 : 3, "0");
 
   // Determine if this Pokemon is ranked (for available context)
-  const isRankedPokemon = context === 'available' && 'isRanked' in pokemon && pokemon.isRanked;
-  const currentRank = isRankedPokemon && 'currentRank' in pokemon ? pokemon.currentRank : null;
+  const isRankedPokemon =
+    context === "available" && "isRanked" in pokemon && pokemon.isRanked;
+  const currentRank =
+    isRankedPokemon && "currentRank" in pokemon ? pokemon.currentRank : null;
 
   return (
     <div
       ref={setNodeRef}
       style={style}
       className={`${backgroundColorClass} rounded-lg border border-gray-200 relative overflow-hidden h-35 flex flex-col group ${
-        isDraggable && !isOpen ? 'cursor-grab active:cursor-grabbing' : ''
+        isDraggable && !isOpen ? "cursor-grab active:cursor-grabbing" : ""
       } ${
-        isDragging ? 'opacity-80 scale-105 shadow-2xl border-blue-400 transform-gpu' : 'hover:shadow-lg transition-all duration-200'
-      } ${isPending ? 'ring-2 ring-blue-400 ring-opacity-50' : ''}`}
+        isDragging
+          ? "opacity-80 scale-105 shadow-2xl border-blue-400 transform-gpu"
+          : "hover:shadow-lg transition-all duration-200"
+      } ${isPending ? "ring-2 ring-blue-400 ring-opacity-50" : ""}`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       {...(isDraggable && !isOpen ? attributes : {})}
@@ -153,14 +199,14 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
     >
       {/* Enhanced drag overlay for better visual feedback */}
       {isDragging && (
-        <div 
+        <div
           className="absolute inset-0 bg-blue-100 bg-opacity-30 rounded-lg pointer-events-none"
-          style={{ transform: 'translateZ(0)' }}
+          style={{ transform: "translateZ(0)" }}
         ></div>
       )}
 
       {/* Dark overlay for already-ranked Pokemon in available section */}
-      {context === 'available' && isRankedPokemon && (
+      {context === "available" && isRankedPokemon && (
         <div className="absolute inset-0 bg-black bg-opacity-40 rounded-lg z-10"></div>
       )}
 
@@ -172,28 +218,43 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       )}
 
       {/* Prioritize button - only visible on card hover */}
-      {!isDragging && (context === 'ranked' || context === 'available') && (
+      {!isDragging && (context === "ranked" || context === "available") && (
         <button
+          data-priority-button="true"
           onPointerDown={(e) => {
             e.stopPropagation();
             e.preventDefault();
-            console.log(`🌥️ [CARD_DEBUG] onPointerDown called for ${pokemon.name}`);
+            console.log(
+              `🌥️ [CARD_DEBUG] onPointerDown called for ${pokemon.name}`,
+            );
+          }}
+          onPointerUp={(e) => {
+            e.stopPropagation();
+          }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
           }}
           onClick={handlePrioritizeClick}
           className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-all duration-300 ${
-            isPendingRefinement 
-              ? 'opacity-100' 
-              : isHovered 
-                ? 'opacity-100' 
-                : 'opacity-0 pointer-events-none'
+            isPendingRefinement
+              ? "opacity-100"
+              : isHovered
+                ? "opacity-100"
+                : "opacity-0 pointer-events-none"
           }`}
-          title={isPendingRefinement ? "Remove from refinement queue" : "Prioritize for refinement battle"}
+          title={
+            isPendingRefinement
+              ? "Remove from refinement queue"
+              : "Prioritize for refinement battle"
+          }
           type="button"
           disabled={!isHydrated}
         >
           <Star
             className={`w-16 h-16 transition-all duration-300 ${
-              isPendingRefinement ? 'text-yellow-400 fill-yellow-400' : 'text-gray-500 hover:text-yellow-500'
+              isPendingRefinement
+                ? "text-yellow-400 fill-yellow-400"
+                : "text-gray-500 hover:text-yellow-500"
             }`}
           />
         </button>
@@ -201,12 +262,14 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
 
       {/* Info Button with Dialog - only visible on card hover */}
       {!isDragging && (
-        <div className={`absolute top-1 right-1 z-30 transition-all duration-300 ${
-          isHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'
-        }`}>
+        <div
+          className={`absolute top-1 right-1 z-30 transition-all duration-300 ${
+            isHovered ? "opacity-100" : "opacity-0 pointer-events-none"
+          }`}
+        >
           <Dialog open={isOpen} onOpenChange={setIsOpen}>
             <DialogTrigger asChild>
-              <button 
+              <button
                 className="w-5 h-5 rounded-full bg-white/80 hover:bg-white border border-gray-300 text-gray-600 hover:text-gray-800 flex items-center justify-center text-xs font-medium shadow-sm transition-all duration-200 backdrop-blur-sm cursor-pointer"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -216,8 +279,8 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
                 i
               </button>
             </DialogTrigger>
-            
-            <DialogContent 
+
+            <DialogContent
               className="max-w-4xl max-h-[90vh] overflow-y-auto pointer-events-auto"
               onClick={handleDialogClick}
               data-radix-dialog-content="true"
@@ -244,60 +307,61 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       )}
 
       {/* Crown badge for ranked Pokemon in available section */}
-      {context === 'available' && isRankedPokemon && currentRank && (
+      {context === "available" && isRankedPokemon && currentRank && (
         <div className="absolute top-2 left-2 z-20">
-          <Badge 
-            variant="secondary" 
+          <Badge
+            variant="secondary"
             className="bg-yellow-500 text-white font-bold text-xs px-2 py-1 shadow-md flex items-center gap-1"
           >
-            <Crown size={12} />
-            #{String(currentRank)}
+            <Crown size={12} />#{String(currentRank)}
           </Badge>
         </div>
       )}
 
       {/* Ranking number */}
-      {context === 'ranked' && showRank && (
-        <div className={`absolute top-2 left-2 w-7 h-7 bg-white rounded-full flex items-center justify-center text-sm font-bold z-10 shadow-sm border border-gray-200 ${
-          isDragging ? 'bg-blue-100 border-blue-300' : ''
-        }`}>
+      {context === "ranked" && showRank && (
+        <div
+          className={`absolute top-2 left-2 w-7 h-7 bg-white rounded-full flex items-center justify-center text-sm font-bold z-10 shadow-sm border border-gray-200 ${
+            isDragging ? "bg-blue-100 border-blue-300" : ""
+          }`}
+        >
           <span className="text-black">{index + 1}</span>
         </div>
       )}
-      
+
       {/* Pokemon image */}
       <div className="flex-1 flex justify-center items-center px-2 pt-6 pb-1">
-        <img 
-          src={pokemon.image} 
+        <img
+          src={pokemon.image}
           alt={pokemon.name}
           className={`w-20 h-20 object-contain transition-all duration-200 ${
-            isDragging ? 'scale-110' : ''
+            isDragging ? "scale-110" : ""
           }`}
-          style={{ 
-            transform: 'translateZ(0)',
-            willChange: isDragging ? 'transform' : 'auto'
+          style={{
+            transform: "translateZ(0)",
+            willChange: isDragging ? "transform" : "auto",
           }}
           loading="lazy"
           onError={(e) => {
             const target = e.target as HTMLImageElement;
-            target.style.display = 'none';
+            target.style.display = "none";
           }}
         />
       </div>
-      
+
       {/* Pokemon info */}
-      <div className={`bg-white text-center py-1.5 px-2 mt-auto border-t border-gray-100 ${
-        isDragging ? 'bg-blue-50' : ''
-      }`}>
+      <div
+        className={`bg-white text-center py-1.5 px-2 mt-auto border-t border-gray-100 ${
+          isDragging ? "bg-blue-50" : ""
+        }`}
+      >
         <h3 className="font-bold text-gray-800 text-sm leading-tight mb-0.5">
           {pokemon.name}
         </h3>
-        <div className="text-xs text-gray-600 mb-1">
-          #{formattedId}
-        </div>
-        
+        <div className="text-xs text-gray-600 mb-1">#{formattedId}</div>
+
         {/* Score display */}
-        {context === 'ranked' && 'score' in pokemon && (
+        {context === "ranked" && "score" in pokemon && (
           <div className="text-xs text-gray-700 font-medium">
             Score: {pokemon.score.toFixed(5)}
           </div>

--- a/src/components/battle/TCGBattleCard.tsx
+++ b/src/components/battle/TCGBattleCard.tsx
@@ -3,13 +3,19 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Pokemon } from "@/services/pokemon";
 import { BattleType } from "@/hooks/battle/types";
 import { usePokemonTCGCard } from "@/hooks/pokemon/usePokemonTCGCard";
-import { 
-  useTCGBattleCardState, 
-  useTCGImageModeListener, 
-  useTCGCleanupEffect 
+import {
+  useTCGBattleCardState,
+  useTCGImageModeListener,
+  useTCGCleanupEffect,
 } from "./tcg/TCGBattleCardHooks";
 import TCGBattleCardContent from "./tcg/TCGBattleCardContent";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import PokemonModalContent from "@/components/pokemon/PokemonModalContent";
 import { usePokemonFlavorText } from "@/hooks/pokemon/usePokemonFlavorText";
 import { Star } from "lucide-react";
@@ -25,269 +31,331 @@ interface TCGBattleCardProps {
   isProcessing?: boolean;
 }
 
-const TCGBattleCard: React.FC<TCGBattleCardProps> = memo(({
-  pokemon,
-  isSelected,
-  battleType,
-  onSelect,
-  isProcessing = false
-}) => {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const {
-    clickTimeoutRef,
-    lastClickTimeRef,
-    isHovered,
-    setIsHovered,
-    currentImageMode,
-    setCurrentImageMode
-  } = useTCGBattleCardState();
+const TCGBattleCard: React.FC<TCGBattleCardProps> = memo(
+  ({ pokemon, isSelected, battleType, onSelect, isProcessing = false }) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const {
+      clickTimeoutRef,
+      lastClickTimeRef,
+      isHovered,
+      setIsHovered,
+      currentImageMode,
+      setCurrentImageMode,
+    } = useTCGBattleCardState();
 
-  // CRITICAL FIX: Use cloud pending battles instead of local state
-  const { isPokemonPending, addPendingPokemon, removePendingPokemon } = useCloudPendingBattles();
-  const isPendingRefinement = isPokemonPending(pokemon.id);
+    // CRITICAL FIX: Use cloud pending battles instead of local state
+    const { isPokemonPending, addPendingPokemon, removePendingPokemon } =
+      useCloudPendingBattles();
+    const isPendingRefinement = isPokemonPending(pokemon.id);
 
-  const { refinementQueue, hasRefinementBattles, queueBattlesForReorder } = useSharedRefinementQueue();
-  const { allPokemon } = usePokemonContext();
+    const { refinementQueue, hasRefinementBattles, queueBattlesForReorder } =
+      useSharedRefinementQueue();
+    const { allPokemon } = usePokemonContext();
 
-  const contextAvailable = Boolean(
-    refinementQueue &&
-    Array.isArray(refinementQueue) &&
-    typeof hasRefinementBattles === 'boolean'
-  );
+    const contextAvailable = Boolean(
+      refinementQueue &&
+        Array.isArray(refinementQueue) &&
+        typeof hasRefinementBattles === "boolean",
+    );
 
-  const hadRefinementBattlesRef = React.useRef(false);
+    const hadRefinementBattlesRef = React.useRef(false);
 
-  React.useEffect(() => {
-    if (hasRefinementBattles) {
-      hadRefinementBattlesRef.current = true;
-    }
-  }, [hasRefinementBattles]);
-
-  React.useEffect(() => {
-    if (
-      contextAvailable &&
-      hasRefinementBattles === false &&
-      isPendingRefinement &&
-      hadRefinementBattlesRef.current
-    ) {
-      removePendingPokemon(pokemon.id);
-      hadRefinementBattlesRef.current = false;
-    }
-  }, [contextAvailable, hasRefinementBattles, isPendingRefinement, pokemon.id, removePendingPokemon]);
-
-  const { tcgCard, isLoading: isLoadingTCG, hasTcgCard } = usePokemonTCGCard(pokemon.name, true);
-  const displayName = pokemon.name;
-  
-  // Hooks for modal content - match manual mode approach
-  const { flavorText, isLoadingFlavor } = usePokemonFlavorText(pokemon.id, isOpen);
-  const { tcgCard: modalTcgCard, secondTcgCard, isLoading: modalIsLoadingTCG, error: tcgError, hasTcgCard: modalHasTcgCard } = usePokemonTCGCard(pokemon.name, isOpen);
-  
-  console.log(`🃏 [TCG_BATTLE_CARD] ${displayName}: TCG loading=${isLoadingTCG}, hasTcgCard=${hasTcgCard}, isProcessing=${isProcessing}`);
-
-  useTCGImageModeListener(setCurrentImageMode);
-  useTCGCleanupEffect(displayName, clickTimeoutRef);
-
-  const handleClick = React.useCallback((e: React.MouseEvent) => {
-    console.log(`🖱️ [INFO_BUTTON_DEBUG] TCGBattleCard ${displayName}: Card clicked`);
-    
-    // Check for info button clicks - match manual mode approach
-    const target = e.target as HTMLElement;
-    const isInfoButtonClick = target.closest('[data-info-button="true"]') || 
-        target.closest('[data-radix-dialog-content]') ||
-        target.closest('[data-radix-dialog-overlay]') ||
-        target.closest('[role="dialog"]');
-    
-    if (isInfoButtonClick) {
-      console.log(`ℹ️ [INFO_BUTTON_DEBUG] TCGBattleCard: Info dialog interaction for ${displayName}, preventing card selection`);
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
-
-    const now = Date.now();
-    
-    // Prevent rapid double-clicks
-    if (now - lastClickTimeRef.current < 300) {
-      console.log(`🚫 TCGBattleCard: Ignoring rapid click on ${displayName}`);
-      return;
-    }
-    
-    lastClickTimeRef.current = now;
-    
-    console.log(`🖱️ TCGBattleCard: Click on ${displayName} (${pokemon.id}) - processing: ${isProcessing}`);
-    
-    if (clickTimeoutRef.current) {
-      clearTimeout(clickTimeoutRef.current);
-    }
-    
-    clickTimeoutRef.current = setTimeout(() => {
-      onSelect(pokemon.id);
-      clickTimeoutRef.current = null;
-    }, 50);
-  }, [pokemon.id, displayName, onSelect, isProcessing]);
-
-  const handleMouseEnter = React.useCallback(() => {
-    console.log(`🔘 [HOVER_DEBUG] TCGBattleCard ${displayName}: Mouse enter - isProcessing: ${isProcessing}`);
-    if (!isProcessing) {
-      setIsHovered(true);
-    }
-  }, [isProcessing, displayName, setIsHovered]);
-
-  const handleMouseLeave = React.useCallback(() => {
-    console.log(`🔘 [HOVER_DEBUG] TCGBattleCard ${displayName}: Mouse leave`);
-    setIsHovered(false);
-  }, [displayName, setIsHovered]);
-
-  const handlePrioritizeClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-
-    console.log(`⭐ [TCG_STAR_TOGGLE_FIXED] Star clicked for ${pokemon.name} - current pending: ${isPendingRefinement}`);
-
-    if (!isPendingRefinement) {
-      // CRITICAL FIX: Use cloud pending system
-      console.log(`⭐ [TCG_STAR_TOGGLE_FIXED] Adding ${pokemon.name} to CLOUD pending state`);
-      addPendingPokemon(pokemon.id);
-
-      if (contextAvailable && allPokemon.length > 1) {
-        const pool = allPokemon.filter(p => p.id !== pokemon.id);
-        const opponents: number[] = [];
-        const copy = [...pool];
-        while (opponents.length < 3 && copy.length > 0) {
-          const rand = Math.floor(Math.random() * copy.length);
-          opponents.push(copy.splice(rand, 1)[0].id);
-        }
-        try {
-          queueBattlesForReorder(pokemon.id, opponents, -1);
-        } catch (error) {
-          console.error('Failed to queue refinement battles from battle card', error);
-        }
+    React.useEffect(() => {
+      if (hasRefinementBattles) {
+        hadRefinementBattlesRef.current = true;
       }
-    } else {
-      // CRITICAL FIX: Use cloud pending system
-      console.log(`⭐ [TCG_STAR_TOGGLE_FIXED] Removing ${pokemon.name} from CLOUD pending state`);
-      removePendingPokemon(pokemon.id);
-    }
-  };
+    }, [hasRefinementBattles]);
 
-  const shouldShowHover = isHovered && !isSelected && !isProcessing && !isLoadingTCG;
+    React.useEffect(() => {
+      if (
+        contextAvailable &&
+        hasRefinementBattles === false &&
+        isPendingRefinement &&
+        hadRefinementBattlesRef.current
+      ) {
+        removePendingPokemon(pokemon.id);
+        hadRefinementBattlesRef.current = false;
+      }
+    }, [
+      contextAvailable,
+      hasRefinementBattles,
+      isPendingRefinement,
+      pokemon.id,
+      removePendingPokemon,
+    ]);
 
-  const cardClasses = `
+    const {
+      tcgCard,
+      isLoading: isLoadingTCG,
+      hasTcgCard,
+    } = usePokemonTCGCard(pokemon.name, true);
+    const displayName = pokemon.name;
+
+    // Hooks for modal content - match manual mode approach
+    const { flavorText, isLoadingFlavor } = usePokemonFlavorText(
+      pokemon.id,
+      isOpen,
+    );
+    const {
+      tcgCard: modalTcgCard,
+      secondTcgCard,
+      isLoading: modalIsLoadingTCG,
+      error: tcgError,
+      hasTcgCard: modalHasTcgCard,
+    } = usePokemonTCGCard(pokemon.name, isOpen);
+
+    console.log(
+      `🃏 [TCG_BATTLE_CARD] ${displayName}: TCG loading=${isLoadingTCG}, hasTcgCard=${hasTcgCard}, isProcessing=${isProcessing}`,
+    );
+
+    useTCGImageModeListener(setCurrentImageMode);
+    useTCGCleanupEffect(displayName, clickTimeoutRef);
+
+    const handleClick = React.useCallback(
+      (e: React.MouseEvent) => {
+        console.log(
+          `🖱️ [INFO_BUTTON_DEBUG] TCGBattleCard ${displayName}: Card clicked`,
+        );
+
+        // Check for info button clicks - match manual mode approach
+        const target = e.target as HTMLElement;
+        const isInfoButtonClick =
+          target.closest('[data-info-button="true"]') ||
+          target.closest("[data-radix-dialog-content]") ||
+          target.closest("[data-radix-dialog-overlay]") ||
+          target.closest('[role="dialog"]');
+        const isStarClick = target.closest('[data-priority-button="true"]');
+
+        if (isInfoButtonClick || isStarClick) {
+          console.log(
+            `ℹ️ [INFO_BUTTON_DEBUG] TCGBattleCard: Info dialog interaction for ${displayName}, preventing card selection`,
+          );
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+
+        const now = Date.now();
+
+        // Prevent rapid double-clicks
+        if (now - lastClickTimeRef.current < 300) {
+          console.log(
+            `🚫 TCGBattleCard: Ignoring rapid click on ${displayName}`,
+          );
+          return;
+        }
+
+        lastClickTimeRef.current = now;
+
+        console.log(
+          `🖱️ TCGBattleCard: Click on ${displayName} (${pokemon.id}) - processing: ${isProcessing}`,
+        );
+
+        if (clickTimeoutRef.current) {
+          clearTimeout(clickTimeoutRef.current);
+        }
+
+        clickTimeoutRef.current = setTimeout(() => {
+          onSelect(pokemon.id);
+          clickTimeoutRef.current = null;
+        }, 50);
+      },
+      [pokemon.id, displayName, onSelect, isProcessing],
+    );
+
+    const handleMouseEnter = React.useCallback(() => {
+      console.log(
+        `🔘 [HOVER_DEBUG] TCGBattleCard ${displayName}: Mouse enter - isProcessing: ${isProcessing}`,
+      );
+      if (!isProcessing) {
+        setIsHovered(true);
+      }
+    }, [isProcessing, displayName, setIsHovered]);
+
+    const handleMouseLeave = React.useCallback(() => {
+      console.log(`🔘 [HOVER_DEBUG] TCGBattleCard ${displayName}: Mouse leave`);
+      setIsHovered(false);
+    }, [displayName, setIsHovered]);
+
+    const handlePrioritizeClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      console.log(
+        `⭐ [TCG_STAR_TOGGLE_FIXED] Star clicked for ${pokemon.name} - current pending: ${isPendingRefinement}`,
+      );
+
+      if (!isPendingRefinement) {
+        // CRITICAL FIX: Use cloud pending system
+        console.log(
+          `⭐ [TCG_STAR_TOGGLE_FIXED] Adding ${pokemon.name} to CLOUD pending state`,
+        );
+        addPendingPokemon(pokemon.id);
+
+        if (contextAvailable && allPokemon.length > 1) {
+          const pool = allPokemon.filter((p) => p.id !== pokemon.id);
+          const opponents: number[] = [];
+          const copy = [...pool];
+          while (opponents.length < 3 && copy.length > 0) {
+            const rand = Math.floor(Math.random() * copy.length);
+            opponents.push(copy.splice(rand, 1)[0].id);
+          }
+          try {
+            queueBattlesForReorder(pokemon.id, opponents, -1);
+          } catch (error) {
+            console.error(
+              "Failed to queue refinement battles from battle card",
+              error,
+            );
+          }
+        }
+      } else {
+        // CRITICAL FIX: Use cloud pending system
+        console.log(
+          `⭐ [TCG_STAR_TOGGLE_FIXED] Removing ${pokemon.name} from CLOUD pending state`,
+        );
+        removePendingPokemon(pokemon.id);
+      }
+    };
+
+    const shouldShowHover =
+      isHovered && !isSelected && !isProcessing && !isLoadingTCG;
+
+    const cardClasses = `
     relative cursor-pointer transition-all duration-200 transform group
-    ${isSelected ? 'ring-4 ring-blue-500 bg-blue-50 scale-105 shadow-xl' : 'hover:scale-105 hover:shadow-lg'}
-    ${isProcessing ? 'pointer-events-none' : ''}
-    ${shouldShowHover ? 'ring-2 ring-blue-300 ring-opacity-50' : ''}
+    ${isSelected ? "ring-4 ring-blue-500 bg-blue-50 scale-105 shadow-xl" : "hover:scale-105 hover:shadow-lg"}
+    ${isProcessing ? "pointer-events-none" : ""}
+    ${shouldShowHover ? "ring-2 ring-blue-300 ring-opacity-50" : ""}
   `.trim();
 
-  const handleDialogClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-  };
+    const handleDialogClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+    };
 
-  // Determine what content to show in modal - match manual mode
-  const showLoading = modalIsLoadingTCG;
-  const showTCGCards = !modalIsLoadingTCG && modalHasTcgCard && modalTcgCard !== null;
-  const showFallbackInfo = !modalIsLoadingTCG && !modalHasTcgCard;
+    // Determine what content to show in modal - match manual mode
+    const showLoading = modalIsLoadingTCG;
+    const showTCGCards =
+      !modalIsLoadingTCG && modalHasTcgCard && modalTcgCard !== null;
+    const showFallbackInfo = !modalIsLoadingTCG && !modalHasTcgCard;
 
-  return (
-    <Card 
-      className={cardClasses}
-      onClick={handleClick}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      data-pokemon-id={pokemon.id}
-      data-pokemon-name={displayName}
-      data-processing={isProcessing ? "true" : "false"}
-      data-hovered={shouldShowHover ? "true" : "false"}
-    >
-      <CardContent className="p-4 text-center relative">
-        {/* Prioritize button - only visible on card hover */}
-        <button
-          onPointerDown={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-          }}
-          onClick={handlePrioritizeClick}
-          className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-all duration-300 ${
-            isPendingRefinement 
-              ? 'opacity-100' 
-              : isHovered && !isProcessing 
-                ? 'opacity-100' 
-                : 'opacity-0 pointer-events-none'
-          }`}
-          title={isPendingRefinement ? "Remove from refinement queue" : "Prioritize for refinement battle"}
-          type="button"
-        >
-          <Star
-            className={`w-16 h-16 transition-all duration-300 ${
-              isPendingRefinement ? 'text-yellow-400 fill-yellow-400' : 'text-gray-500 hover:text-yellow-500'
+    return (
+      <Card
+        className={cardClasses}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        data-pokemon-id={pokemon.id}
+        data-pokemon-name={displayName}
+        data-processing={isProcessing ? "true" : "false"}
+        data-hovered={shouldShowHover ? "true" : "false"}
+      >
+        <CardContent className="p-4 text-center relative">
+          {/* Prioritize button - only visible on card hover */}
+          <button
+            data-priority-button="true"
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            onPointerUp={(e) => {
+              e.stopPropagation();
+            }}
+            onMouseUp={(e) => {
+              e.stopPropagation();
+            }}
+            onClick={handlePrioritizeClick}
+            className={`absolute top-1/2 right-2 -translate-y-1/2 z-30 p-2 rounded-full transition-all duration-300 ${
+              isPendingRefinement
+                ? "opacity-100"
+                : isHovered && !isProcessing
+                  ? "opacity-100"
+                  : "opacity-0 pointer-events-none"
             }`}
-          />
-        </button>
+            title={
+              isPendingRefinement
+                ? "Remove from refinement queue"
+                : "Prioritize for refinement battle"
+            }
+            type="button"
+          >
+            <Star
+              className={`w-16 h-16 transition-all duration-300 ${
+                isPendingRefinement
+                  ? "text-yellow-400 fill-yellow-400"
+                  : "text-gray-500 hover:text-yellow-500"
+              }`}
+            />
+          </button>
 
-        {/* Info Button - only visible on card hover */}
-        <div className={`absolute top-1 right-1 z-30 transition-all duration-300 ${
-          isHovered && !isProcessing ? 'opacity-100' : 'opacity-0 pointer-events-none'
-        }`}>
-          <Dialog open={isOpen} onOpenChange={setIsOpen}>
-            <DialogTrigger asChild>
-              <button 
-                className="w-5 h-5 rounded-full bg-white/80 hover:bg-white border border-gray-300 text-gray-600 hover:text-gray-800 flex items-center justify-center text-xs font-medium shadow-sm transition-all duration-200 backdrop-blur-sm cursor-pointer"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  console.log(`Info button clicked for ${pokemon.name}`);
-                }}
-                onPointerDown={(e) => {
-                  e.stopPropagation();
-                }}
-                onMouseDown={(e) => {
-                  e.stopPropagation();
-                }}
-                type="button"
-                style={{ pointerEvents: 'auto' }}
+          {/* Info Button - only visible on card hover */}
+          <div
+            className={`absolute top-1 right-1 z-30 transition-all duration-300 ${
+              isHovered && !isProcessing
+                ? "opacity-100"
+                : "opacity-0 pointer-events-none"
+            }`}
+          >
+            <Dialog open={isOpen} onOpenChange={setIsOpen}>
+              <DialogTrigger asChild>
+                <button
+                  className="w-5 h-5 rounded-full bg-white/80 hover:bg-white border border-gray-300 text-gray-600 hover:text-gray-800 flex items-center justify-center text-xs font-medium shadow-sm transition-all duration-200 backdrop-blur-sm cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    console.log(`Info button clicked for ${pokemon.name}`);
+                  }}
+                  onPointerDown={(e) => {
+                    e.stopPropagation();
+                  }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                  }}
+                  type="button"
+                  style={{ pointerEvents: "auto" }}
+                >
+                  i
+                </button>
+              </DialogTrigger>
+
+              <DialogContent
+                className="max-w-4xl max-h-[90vh] overflow-y-auto pointer-events-auto"
+                onClick={handleDialogClick}
+                data-radix-dialog-content="true"
               >
-                i
-              </button>
-            </DialogTrigger>
-            
-            <DialogContent 
-              className="max-w-4xl max-h-[90vh] overflow-y-auto pointer-events-auto"
-              onClick={handleDialogClick}
-              data-radix-dialog-content="true"
-            >
-              <DialogHeader>
-                <DialogTitle className="text-2xl font-bold text-center">
-                  {pokemon.name}
-                </DialogTitle>
-              </DialogHeader>
+                <DialogHeader>
+                  <DialogTitle className="text-2xl font-bold text-center">
+                    {pokemon.name}
+                  </DialogTitle>
+                </DialogHeader>
 
-              <PokemonModalContent
-                pokemon={pokemon}
-                showLoading={showLoading}
-                showTCGCards={showTCGCards}
-                showFallbackInfo={showFallbackInfo}
-                tcgCard={modalTcgCard}
-                secondTcgCard={secondTcgCard}
-                flavorText={flavorText}
-                isLoadingFlavor={isLoadingFlavor}
-              />
-            </DialogContent>
-          </Dialog>
-        </div>
+                <PokemonModalContent
+                  pokemon={pokemon}
+                  showLoading={showLoading}
+                  showTCGCards={showTCGCards}
+                  showFallbackInfo={showFallbackInfo}
+                  tcgCard={modalTcgCard}
+                  secondTcgCard={secondTcgCard}
+                  flavorText={flavorText}
+                  isLoadingFlavor={isLoadingFlavor}
+                />
+              </DialogContent>
+            </Dialog>
+          </div>
 
-        <TCGBattleCardContent
-          pokemon={pokemon}
-          displayName={displayName}
-          isLoadingTCG={isLoadingTCG}
-          hasTcgCard={hasTcgCard}
-          tcgCard={tcgCard}
-          shouldShowHover={shouldShowHover}
-          isSelected={isSelected}
-          isProcessing={isProcessing}
-        />
-      </CardContent>
-    </Card>
-  );
-});
+          <TCGBattleCardContent
+            pokemon={pokemon}
+            displayName={displayName}
+            isLoadingTCG={isLoadingTCG}
+            hasTcgCard={hasTcgCard}
+            tcgCard={tcgCard}
+            shouldShowHover={shouldShowHover}
+            isSelected={isSelected}
+            isProcessing={isProcessing}
+          />
+        </CardContent>
+      </Card>
+    );
+  },
+);
 
 TCGBattleCard.displayName = "TCGBattleCard";
 


### PR DESCRIPTION
## Summary
- ensure `AppContent` waits for store hydration before dispatching `mode-switch`
- block pointerup/mouseup propagation on star button in battle cards

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6849080333d483338e1c2c8e15506ca5