### PR TITLE
Fix overflow to show dragging

### DIFF
--- a/src/components/ranking/EnhancedAvailablePokemonContent.tsx
+++ b/src/components/ranking/EnhancedAvailablePokemonContent.tsx
@@ -127,9 +127,9 @@ export const EnhancedAvailablePokemonContent: React.FC<EnhancedAvailablePokemonC
   };
 
   return (
-    <div 
+    <div
       ref={setNodeRef}
-      className="flex-1 overflow-y-auto p-4 transition-colors"
+      className="flex-1 overflow-y-visible overflow-x-visible p-4 transition-colors"
     >
       <div className="space-y-4">
         {renderContent()}


### PR DESCRIPTION
## Summary
- allow content to extend outside the available Pokémon container

## Testing
- `npm run lint` *(fails: unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f679d83688333aa4256622a03a723