### PR TITLE
Fix drag overlay behavior

### DIFF
--- a/src/components/battle/DragDropGrid.tsx
+++ b/src/components/battle/DragDropGrid.tsx
@@ -43,7 +43,7 @@ const SortableRankedCard: React.FC<{
     transform: !isDragging && transform ? CSS.Translate.toString(transform) : undefined,
     transition,
     opacity: isDragging ? 0 : 1,
-    zIndex: isDragging ? 1000 : 'auto',
+    zIndex: isDragging ? 'auto' : 1,
     visibility: 'visible',
     display: 'block',
   };

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -91,14 +91,16 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   const { attributes, listeners, setNodeRef, transform, isDragging } = isAvailableContext ? draggable : sortable;
   const transition = !isAvailableContext ? sortable.transition : undefined;
 
-  const style = {
-    transform: !isDragging ? CSS.Transform.toString(transform) : undefined,
+  const style: React.CSSProperties = {
     transition,
-    opacity: isDragging ? 0 : 1,
     minHeight: '140px',
     minWidth: '140px',
-    zIndex: isDragging ? 1000 : 'auto',
     cursor: isDraggable && !isOpen ? 'grab' : 'default',
+    opacity: isDragging ? 0 : 1,
+    transform: isAvailableContext || isDragging
+      ? undefined
+      : CSS.Transform.toString(transform),
+    zIndex: isDragging ? 'auto' : 1,
     willChange: 'transform' as const,
     backfaceVisibility: 'hidden' as const,
   };

--- a/src/components/ranking/RankingGrid.tsx
+++ b/src/components/ranking/RankingGrid.tsx
@@ -140,7 +140,7 @@ const SortableRankingCard: React.FC<{
     transform: !isDragging ? CSS.Translate.toString(transform) : undefined,
     transition,
     opacity: isDragging ? 0 : 1,
-    zIndex: isDragging ? 100 : 'auto',
+    zIndex: isDragging ? 'auto' : 1,
   };
 
   return (


### PR DESCRIPTION
## Summary
- prevent ranked cards from moving when dragged
- hide dragged cards in various grids so overlay handles movement

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f6f0af59c8333af544abeaae0b591