### PR TITLE
Fix drag overlay behavior

### DIFF
--- a/src/components/battle/DragDropGrid.tsx
+++ b/src/components/battle/DragDropGrid.tsx
@@ -43,7 +43,7 @@ const SortableRankedCard: React.FC<{
     transform: !isDragging && transform ? CSS.Translate.toString(transform) : undefined,
     transition,
     opacity: isDragging ? 0 : 1,
-    zIndex: isDragging ? 1000 : 'auto',
+    zIndex: isDragging ? 'auto' : 1,
     visibility: 'visible',
     display: 'block',
   };
@@ -62,7 +62,6 @@ const SortableRankedCard: React.FC<{
         showRank={true}
         isDraggable={true}
         isAvailable={false}
-        context="ranked"
         allRankedPokemon={allRankedPokemon}
       />
     </div>

--- a/src/components/battle/DraggableMilestoneGrid.tsx
+++ b/src/components/battle/DraggableMilestoneGrid.tsx
@@ -126,7 +126,6 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
           index={index}
           showRank={true}
           isDraggable={!!onManualReorder}
-          context="ranked"
           isPending={localPendingRefinements.has(pokemon.id)}
           allRankedPokemon={displayRankings}
         />
@@ -166,7 +165,6 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
                 index={displayRankings.findIndex(p => p.id === activePokemon.id)}
                 showRank={true}
                 isDraggable={false}
-                context="ranked"
                 isPending={localPendingRefinements.has(activePokemon.id)}
                 allRankedPokemon={displayRankings}
               />

--- a/src/components/pokemon/LazyPokemonGrid.tsx
+++ b/src/components/pokemon/LazyPokemonGrid.tsx
@@ -81,7 +81,6 @@ export const LazyPokemonGrid: React.FC<LazyPokemonGridProps> = ({
                     showRank={isRankingArea}
                     isDraggable={true}
                     isAvailable={!isRankingArea}
-                    context={isRankingArea ? "ranked" : "available"}
                     allRankedPokemon={isRankingArea ? rankedList : []}
                   />
                 );

--- a/src/components/pokemon/PokemonListContent.tsx
+++ b/src/components/pokemon/PokemonListContent.tsx
@@ -96,7 +96,6 @@ export const PokemonListContent: React.FC<PokemonListContentProps> = ({
                 showRank={false}
                 isDraggable={true}
                 isAvailable={true}
-                context="available"
               />
             );
           }

--- a/src/components/ranking/EnhancedAvailablePokemonContent.tsx
+++ b/src/components/ranking/EnhancedAvailablePokemonContent.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useDroppable } from '@dnd-kit/core';
+import { useDraggable } from '@dnd-kit/core';
 import DraggablePokemonMilestoneCard from "@/components/battle/DraggablePokemonMilestoneCard";
 import GenerationHeader from "@/components/pokemon/GenerationHeader";
 
@@ -20,6 +21,38 @@ interface EnhancedAvailablePokemonContentProps {
 const PokemonLoadingPlaceholder = () => (
   <div className="animate-pulse bg-gray-200 rounded-lg h-32 w-full"></div>
 );
+
+const DraggableAvailableCard: React.FC<{ pokemon: any; index: number; allRankedPokemon: any[] }> = ({ pokemon, index, allRankedPokemon }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `available-${pokemon.id}`,
+    data: {
+      type: 'available-pokemon',
+      pokemon,
+      source: 'available',
+      index,
+      isRanked: 'isRanked' in pokemon && pokemon.isRanked
+    },
+  });
+
+  const style: React.CSSProperties = {
+    opacity: isDragging ? 0 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
+      <DraggablePokemonMilestoneCard
+        key={pokemon.id}
+        pokemon={pokemon}
+        index={index}
+        isPending={false}
+        showRank={false}
+        isDraggable={true}
+        isAvailable={true}
+        allRankedPokemon={allRankedPokemon}
+      />
+    </div>
+  );
+};
 
 export const EnhancedAvailablePokemonContent: React.FC<EnhancedAvailablePokemonContentProps> = ({
   items,
@@ -65,15 +98,10 @@ export const EnhancedAvailablePokemonContent: React.FC<EnhancedAvailablePokemonC
           result.push(
             <div key={`gen-${currentGeneration}-pokemon`} className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))' }}>
               {currentGenerationPokemon.map((pokemon, index) => (
-                <DraggablePokemonMilestoneCard
+                <DraggableAvailableCard
                   key={pokemon.id}
                   pokemon={pokemon}
                   index={index}
-                  isPending={false}
-                  showRank={false}
-                  isDraggable={true}
-                  isAvailable={true}
-                  context="available"
                   allRankedPokemon={allRankedPokemon}
                 />
               ))}
@@ -107,15 +135,10 @@ export const EnhancedAvailablePokemonContent: React.FC<EnhancedAvailablePokemonC
       result.push(
         <div key={`gen-${currentGeneration}-pokemon-final`} className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))' }}>
           {currentGenerationPokemon.map((pokemon, index) => (
-            <DraggablePokemonMilestoneCard
+            <DraggableAvailableCard
               key={pokemon.id}
               pokemon={pokemon}
               index={index}
-              isPending={false}
-              showRank={false}
-              isDraggable={true}
-              isAvailable={true}
-              context="available"
               allRankedPokemon={allRankedPokemon}
             />
           ))}

--- a/src/components/ranking/RankingGrid.tsx
+++ b/src/components/ranking/RankingGrid.tsx
@@ -140,7 +140,7 @@ const SortableRankingCard: React.FC<{
     transform: !isDragging ? CSS.Translate.toString(transform) : undefined,
     transition,
     opacity: isDragging ? 0 : 1,
-    zIndex: isDragging ? 100 : 'auto',
+    zIndex: isDragging ? 'auto' : 1,
   };
 
   return (
@@ -152,7 +152,6 @@ const SortableRankingCard: React.FC<{
         showRank={true}
         isDraggable={true}
         isAvailable={false}
-        context="ranked"
         allRankedPokemon={allRankedPokemon}
       />
     </div>

--- a/src/components/rankings/GlobalRankingsView.tsx
+++ b/src/components/rankings/GlobalRankingsView.tsx
@@ -220,7 +220,6 @@ const GlobalRankingsView: React.FC<GlobalRankingsViewProps> = ({
                 index={index}
                 showRank={true}
                 isDraggable={false}
-                context="ranked"
                 allRankedPokemon={displayRankings}
               />
             ))}


### PR DESCRIPTION
## Summary
- refactor DraggablePokemonMilestoneCard to remove dnd-kit logic
- create DraggableAvailableCard wrapper for available list
- update ranking and available grids to hide source card while dragging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f6f0af59c8333af544abeaae0b591