### PR TITLE
Refactor draggable card wrappers

### DIFF
--- a/src/components/battle/DragDropGrid.tsx
+++ b/src/components/battle/DragDropGrid.tsx
@@ -40,12 +40,9 @@ const SortableRankedCard: React.FC<{
   });
 
   const style: React.CSSProperties = {
-    transform: !isDragging && transform ? CSS.Translate.toString(transform) : undefined,
+    transform: CSS.Translate.toString(transform),
     transition,
     opacity: isDragging ? 0 : 1,
-    zIndex: isDragging ? 'auto' : 1,
-    visibility: 'visible',
-    display: 'block',
   };
 
   return (
@@ -62,7 +59,6 @@ const SortableRankedCard: React.FC<{
         showRank={true}
         isDraggable={true}
         isAvailable={false}
-        context="ranked"
         allRankedPokemon={allRankedPokemon}
       />
     </div>

--- a/src/components/battle/DraggableMilestoneGrid.tsx
+++ b/src/components/battle/DraggableMilestoneGrid.tsx
@@ -126,7 +126,6 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
           index={index}
           showRank={true}
           isDraggable={!!onManualReorder}
-          context="ranked"
           isPending={localPendingRefinements.has(pokemon.id)}
           allRankedPokemon={displayRankings}
         />
@@ -166,7 +165,6 @@ const DraggableMilestoneGrid: React.FC<DraggableMilestoneGridProps> = ({
                 index={displayRankings.findIndex(p => p.id === activePokemon.id)}
                 showRank={true}
                 isDraggable={false}
-                context="ranked"
                 isPending={localPendingRefinements.has(activePokemon.id)}
                 allRankedPokemon={displayRankings}
               />

--- a/src/components/battle/DraggablePokemonMilestoneCard.tsx
+++ b/src/components/battle/DraggablePokemonMilestoneCard.tsx
@@ -1,7 +1,4 @@
 import React from "react";
-import { useSortable } from '@dnd-kit/sortable';
-import { useDraggable } from '@dnd-kit/core';
-import { CSS } from '@dnd-kit/utilities';
 import { Pokemon, RankedPokemon } from "@/services/pokemon";
 import { getPokemonBackgroundColor } from "./utils/PokemonColorUtils";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
@@ -19,7 +16,6 @@ interface DraggablePokemonMilestoneCardProps {
   showRank?: boolean;
   isDraggable?: boolean;
   isAvailable?: boolean;
-  context?: 'available' | 'ranked';
   allRankedPokemon?: (Pokemon | RankedPokemon)[];
 }
 
@@ -30,7 +26,6 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   showRank = true,
   isDraggable = true,
   isAvailable = false,
-  context = 'ranked',
   allRankedPokemon = []
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -63,46 +58,10 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   // Check if this Pokemon has pending state
   const isPendingRefinement = isPokemonPending(pokemon.id);
 
-  // If context is 'available', we want to use useDraggable because there's no SortableContext.
-  // If context is 'ranked', the parent SortableRankedCard handles sorting.
-  const isAvailableContext = context === 'available';
-
-  const id = isDraggable ? (isAvailable ? `available-${pokemon.id}` : pokemon.id.toString()) : `static-${pokemon.id}`;
-  const data = {
-    type: isAvailableContext ? 'available-pokemon' : 'ranked-pokemon',
-    pokemon: pokemon,
-    source: context,
-    index,
-    isRanked: context === 'available' && 'isRanked' in pokemon && pokemon.isRanked
-  };
-
-  const draggable = useDraggable({
-    id,
-    data,
-    disabled: !isDraggable || isOpen || !isAvailableContext,
-  });
-  
-  const sortable = useSortable({ 
-    id,
-    data,
-    disabled: !isDraggable || isOpen || isAvailableContext,
-  });
-  
-  const { attributes, listeners, setNodeRef, transform, isDragging } = isAvailableContext ? draggable : sortable;
-  const transition = !isAvailableContext ? sortable.transition : undefined;
-
   const style: React.CSSProperties = {
-    transition,
     minHeight: '140px',
     minWidth: '140px',
     cursor: isDraggable && !isOpen ? 'grab' : 'default',
-    opacity: isDragging ? 0 : 1,
-    transform: isAvailableContext || isDragging
-      ? undefined
-      : CSS.Transform.toString(transform),
-    zIndex: isDragging ? 'auto' : 1,
-    willChange: 'transform' as const,
-    backfaceVisibility: 'hidden' as const,
   };
 
 
@@ -122,9 +81,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   };
 
   const handleMouseEnter = () => {
-    if (!isDragging) {
-      setIsHovered(true);
-    }
+    setIsHovered(true);
   };
 
   const handleMouseLeave = () => {
@@ -134,34 +91,22 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
   // Format Pokemon ID with leading zeros
   const formattedId = pokemon.id.toString().padStart(pokemon.id >= 10000 ? 5 : 3, '0');
 
-  // Determine if this Pokemon is ranked (for available context)
-  const isRankedPokemon = context === 'available' && 'isRanked' in pokemon && pokemon.isRanked;
+  // Determine if this Pokemon is ranked when shown in the available list
+  const isRankedPokemon = isAvailable && 'isRanked' in pokemon && pokemon.isRanked;
   const currentRank = isRankedPokemon && 'currentRank' in pokemon ? pokemon.currentRank : null;
 
   return (
     <div
-      ref={isAvailableContext ? setNodeRef : null}
       style={style}
       className={`${backgroundColorClass} rounded-lg border border-gray-200 relative overflow-hidden h-35 flex flex-col group ${
-        isDraggable && !isOpen ? 'cursor-grab active:cursor-grabbing' : ''
-      } ${
-        isDragging ? 'shadow-2xl border-blue-400' : 'hover:shadow-lg transition-all duration-200'
-      } ${isPending ? 'ring-2 ring-blue-400 ring-opacity-50' : ''}`}
+        isDraggable ? 'cursor-grab' : ''
+      } hover:shadow-lg transition-all duration-200 ${isPending ? 'ring-2 ring-blue-400 ring-opacity-50' : ''}`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      {...(isDraggable && !isOpen && isAvailableContext ? attributes : {})}
-      {...(isDraggable && !isOpen && isAvailableContext ? listeners : {})}
     >
-      {/* Enhanced drag overlay for better visual feedback */}
-      {isDragging && (
-        <div 
-          className="absolute inset-0 bg-blue-100 bg-opacity-30 rounded-lg pointer-events-none"
-          style={{ transform: 'translateZ(0)' }}
-        ></div>
-      )}
 
       {/* Dark overlay for already-ranked Pokemon in available section */}
-      {context === 'available' && isRankedPokemon && (
+      {isAvailable && isRankedPokemon && (
         <div className="absolute inset-0 bg-black bg-opacity-40 rounded-lg z-10"></div>
       )}
 
@@ -170,10 +115,10 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
         <div className="absolute top-0 left-0 right-0 bg-blue-500 text-white text-xs py-1 px-2 z-20">
           Pending Battle
         </div>
-      )}
+      )
 
       {/* Prioritize button - only visible on card hover */}
-      {!isDragging && (context === 'ranked' || context === 'available') && (
+      (
         <button
           onPointerDown={(e) => {
             e.stopPropagation();
@@ -203,10 +148,10 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
             }`}
           />
         </button>
-      )}
+      )
 
       {/* Info Button with Dialog - only visible on card hover */}
-      {!isDragging && (
+      (
         <div className={`absolute top-1 right-1 z-30 transition-all duration-300 ${
           isHovered ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}>
@@ -250,7 +195,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       )}
 
       {/* Crown badge for ranked Pokemon in available section */}
-      {context === 'available' && isRankedPokemon && currentRank && (
+      {isAvailable && isRankedPokemon && currentRank && (
         <div className="absolute top-2 left-2 z-20">
           <Badge 
             variant="secondary" 
@@ -263,10 +208,8 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       )}
 
       {/* Ranking number */}
-      {context === 'ranked' && showRank && (
-        <div className={`absolute top-2 left-2 w-7 h-7 bg-white rounded-full flex items-center justify-center text-sm font-bold z-10 shadow-sm border border-gray-200 ${
-          isDragging ? 'bg-blue-100 border-blue-300' : ''
-        }`}>
+      {!isAvailable && showRank && (
+        <div className="absolute top-2 left-2 w-7 h-7 bg-white rounded-full flex items-center justify-center text-sm font-bold z-10 shadow-sm border border-gray-200">
           <span className="text-black">{index + 1}</span>
         </div>
       )}
@@ -276,12 +219,9 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
         <img 
           src={pokemon.image} 
           alt={pokemon.name}
-          className={`w-20 h-20 object-contain transition-all duration-200 ${
-            isDragging && isAvailableContext ? 'scale-110' : ''
-          }`}
-          style={{ 
-            transform: 'translateZ(0)',
-            willChange: isDragging && isAvailableContext ? 'transform' : 'auto'
+          className="w-20 h-20 object-contain transition-all duration-200"
+          style={{
+            transform: 'translateZ(0)'
           }}
           loading="lazy"
           onError={(e) => {
@@ -292,9 +232,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
       </div>
       
       {/* Pokemon info */}
-      <div className={`bg-white text-center py-1.5 px-2 mt-auto border-t border-gray-100 ${
-        isDragging && isAvailableContext ? 'bg-blue-50' : ''
-      }`}>
+      <div className="bg-white text-center py-1.5 px-2 mt-auto border-t border-gray-100">
         <h3 className="font-bold text-gray-800 text-sm leading-tight mb-0.5">
           {pokemon.name}
         </h3>
@@ -303,7 +241,7 @@ const DraggablePokemonMilestoneCard: React.FC<DraggablePokemonMilestoneCardProps
         </div>
         
         {/* Score display */}
-        {context === 'ranked' && 'score' in pokemon && (
+        {!isAvailable && 'score' in pokemon && (
           <div className="text-xs text-gray-700 font-medium">
             Score: {pokemon.score.toFixed(5)}
           </div>

--- a/src/components/pokemon/LazyPokemonGrid.tsx
+++ b/src/components/pokemon/LazyPokemonGrid.tsx
@@ -81,7 +81,6 @@ export const LazyPokemonGrid: React.FC<LazyPokemonGridProps> = ({
                     showRank={isRankingArea}
                     isDraggable={true}
                     isAvailable={!isRankingArea}
-                    context={isRankingArea ? "ranked" : "available"}
                     allRankedPokemon={isRankingArea ? rankedList : []}
                   />
                 );

--- a/src/components/pokemon/PokemonListContent.tsx
+++ b/src/components/pokemon/PokemonListContent.tsx
@@ -96,7 +96,6 @@ export const PokemonListContent: React.FC<PokemonListContentProps> = ({
                 showRank={false}
                 isDraggable={true}
                 isAvailable={true}
-                context="available"
               />
             );
           }

--- a/src/components/ranking/EnhancedAvailablePokemonContent.tsx
+++ b/src/components/ranking/EnhancedAvailablePokemonContent.tsx
@@ -1,7 +1,42 @@
 import React from "react";
-import { useDroppable } from '@dnd-kit/core';
+import { useDroppable, useDraggable } from '@dnd-kit/core';
 import DraggablePokemonMilestoneCard from "@/components/battle/DraggablePokemonMilestoneCard";
 import GenerationHeader from "@/components/pokemon/GenerationHeader";
+
+// ===================================================================
+// 1. DEFINE THE NEW WRAPPER COMPONENT HERE
+// ===================================================================
+const DraggableAvailableCard: React.FC<{ pokemon: any; index: number; allRankedPokemon: any[] }> = ({ pokemon, index, allRankedPokemon }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `available-${pokemon.id}`,
+    data: {
+      type: 'available-pokemon',
+      pokemon: pokemon,
+      source: 'available',
+      index,
+      isRanked: 'isRanked' in pokemon && pokemon.isRanked
+    },
+  });
+
+  const style: React.CSSProperties = {
+    opacity: isDragging ? 0 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
+      <DraggablePokemonMilestoneCard
+        key={pokemon.id}
+        pokemon={pokemon}
+        index={index}
+        isPending={false}
+        showRank={false}
+        isDraggable={true}
+        isAvailable={true}
+        allRankedPokemon={allRankedPokemon}
+      />
+    </div>
+  );
+};
 
 interface EnhancedAvailablePokemonContentProps {
   items: any[];
@@ -65,15 +100,10 @@ export const EnhancedAvailablePokemonContent: React.FC<EnhancedAvailablePokemonC
           result.push(
             <div key={`gen-${currentGeneration}-pokemon`} className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))' }}>
               {currentGenerationPokemon.map((pokemon, index) => (
-                <DraggablePokemonMilestoneCard
+                <DraggableAvailableCard
                   key={pokemon.id}
                   pokemon={pokemon}
                   index={index}
-                  isPending={false}
-                  showRank={false}
-                  isDraggable={true}
-                  isAvailable={true}
-                  context="available"
                   allRankedPokemon={allRankedPokemon}
                 />
               ))}
@@ -107,15 +137,10 @@ export const EnhancedAvailablePokemonContent: React.FC<EnhancedAvailablePokemonC
       result.push(
         <div key={`gen-${currentGeneration}-pokemon-final`} className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))' }}>
           {currentGenerationPokemon.map((pokemon, index) => (
-            <DraggablePokemonMilestoneCard
+            <DraggableAvailableCard
               key={pokemon.id}
               pokemon={pokemon}
               index={index}
-              isPending={false}
-              showRank={false}
-              isDraggable={true}
-              isAvailable={true}
-              context="available"
               allRankedPokemon={allRankedPokemon}
             />
           ))}

--- a/src/components/ranking/RankingGrid.tsx
+++ b/src/components/ranking/RankingGrid.tsx
@@ -152,7 +152,6 @@ const SortableRankingCard: React.FC<{
         showRank={true}
         isDraggable={true}
         isAvailable={false}
-        context="ranked"
         allRankedPokemon={allRankedPokemon}
       />
     </div>

--- a/src/components/rankings/GlobalRankingsView.tsx
+++ b/src/components/rankings/GlobalRankingsView.tsx
@@ -220,7 +220,7 @@ const GlobalRankingsView: React.FC<GlobalRankingsViewProps> = ({
                 index={index}
                 showRank={true}
                 isDraggable={false}
-                context="ranked"
+                isAvailable={false}
                 allRankedPokemon={displayRankings}
               />
             ))}


### PR DESCRIPTION
## Summary
- make `DraggablePokemonMilestoneCard` purely presentational
- add `DraggableAvailableCard` wrapper for use in the available list
- hide dragged sortable cards correctly
- drop obsolete `context` prop from call sites

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f7bb070cc8333a691ac20b605a04c