### PR TITLE
Fix ranking movement state updates

### DIFF
--- a/src/hooks/ranking/usePokemonMovement.ts
+++ b/src/hooks/ranking/usePokemonMovement.ts
@@ -14,24 +14,9 @@ export const usePokemonMovement = (
   ): Promise<boolean> => {
     console.log(`[Move] Attempting to move ${pokemon.name} (ID: ${pokemonId}) to position ${insertionPosition}`);
     try {
-      // Step 1: Remove from available list atomically
-      let removalSuccess = false;
-      setAvailablePokemon(prev => {
-        const pokemonExists = prev.some(p => p.id === pokemonId);
-        console.log(`[Move] Checking available list. Pokemon ${pokemonId} exists: ${pokemonExists}`);
-        if (pokemonExists) {
-          removalSuccess = true;
-          return prev.filter(p => p.id !== pokemonId);
-        }
-        return prev;
-      });
-      
-      if (!removalSuccess) {
-        console.error(`[Move] Failed to remove ${pokemon.name} from available list (not found).`);
-        toast({ title: "Move Error", description: `${pokemon.name} could not be found in the available list.`, variant: 'destructive' });
-        return false;
-      }
-      
+      // Step 1: Remove from available list if function provided
+      setAvailablePokemon?.(prev => prev.filter(p => p.id !== pokemonId));
+
       console.log(`[Move] Removed ${pokemon.name} from available list. Adding to rankings.`);
       // Step 2: Add to rankings using the enhanced manual reorder
       handleEnhancedManualReorder(pokemonId, -1, insertionPosition);
@@ -47,7 +32,7 @@ export const usePokemonMovement = (
     } catch (error) {
       console.error('[Move] Error during moveFromAvailableToRankings:', error);
       // Rollback: Try to restore Pokemon to available list
-      setAvailablePokemon(prev => {
+      setAvailablePokemon?.(prev => {
         const pokemonExists = prev.some(p => p.id === pokemonId);
         if (!pokemonExists) {
           return [...prev, pokemon];

--- a/src/hooks/usePokemonRanker.ts
+++ b/src/hooks/usePokemonRanker.ts
@@ -14,6 +14,7 @@ export const usePokemonRanker = () => {
   
   const {
     rankedPokemonState: rankedPokemon,
+    setAvailablePokemon,
     setRankedPokemon,
     confidenceScores,
     setConfidenceScores,
@@ -98,7 +99,7 @@ export const usePokemonRanker = () => {
     isLoading,
     availablePokemon,
     rankedPokemon,
-    setAvailablePokemon: setRankedPokemon,
+    setAvailablePokemon,
     setRankedPokemon,
     confidenceScores,
     setConfidenceScores,


### PR DESCRIPTION
## Summary
- return `setAvailablePokemon` from usePokemonRanker
- simplify Pokemon movement logic when dragging from available list

## Testing
- `npm run lint` *(fails: 407 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859a292b6e8833393256e1375ab992c