### PR TITLE
Enable dropping Pokémon into rankings

### DIFF
--- a/src/components/battle/DragDropGrid.tsx
+++ b/src/components/battle/DragDropGrid.tsx
@@ -15,7 +15,7 @@ interface DragDropGridProps {
     destinationIndex: number
   ) => void;
   onLocalReorder?: (newRankings: (Pokemon | RankedPokemon)[]) => void;
-  availablePokemon?: any[];
+  availablePokemon?: (Pokemon | RankedPokemon)[];
 }
 
 const DragDropGrid: React.FC<DragDropGridProps> = ({
@@ -43,7 +43,7 @@ const DragDropGrid: React.FC<DragDropGridProps> = ({
       >
         {/* Sorted / reorderable ranked cards */}
         <SortableContext
-          items={displayRankings.map((p) => `ranked-${(p as any).id}`)}
+          items={displayRankings.map((p) => `ranked-${p.id}`)}
           strategy={rectSortingStrategy}
         >
           <div
@@ -56,11 +56,11 @@ const DragDropGrid: React.FC<DragDropGridProps> = ({
           >
             {displayRankings.map((pokemon, index) => (
               <SortablePokemonCard
-                key={(pokemon as any).id}
-                id={`ranked-${(pokemon as any).id}`}
+                key={pokemon.id}
+                id={`ranked-${pokemon.id}`}
                 pokemon={pokemon}
                 index={index}
-                isPending={localPendingRefinements.has((pokemon as any).id)}
+                isPending={localPendingRefinements.has(pokemon.id)}
                 allRankedPokemon={displayRankings}
               />
             ))}

--- a/src/components/ranking/RankingUICore.tsx
+++ b/src/components/ranking/RankingUICore.tsx
@@ -85,8 +85,7 @@ export const RankingUICore: React.FC<RankingUICoreProps> = ({
     localRankings,
     setAvailablePokemon,
     handleEnhancedManualReorder,
-    triggerReRanking,
-    updateLocalRankings
+    triggerReRanking
   );
 
   // Handle local reordering (for DragDropGrid compatibility)


### PR DESCRIPTION
## Summary
- make rankings grid a proper droppable zone
- handle drops from available list onto ranking cards or empty space
- remove unused updateLocalRankings argument

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 412 problems including no-explicit-any in unrelated files)*
- `npx eslint src/components/battle/DragDropGrid.tsx src/hooks/ranking/useEnhancedRankingDragDrop.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a005e47afc8333ae917b082f44840d